### PR TITLE
fix: add missing user field to checker agent example

### DIFF
--- a/agents/checker.md
+++ b/agents/checker.md
@@ -4,6 +4,7 @@ description: |
 
   <example>
   Context: User runs /nlpm:check on a plugin directory
+  user: "/nlpm:check"
   assistant: "I'll use the checker to verify cross-component consistency."
   </example>
   <example>


### PR DESCRIPTION
## Summary
- `agents/checker.md` first example block was missing the `user:` field
- Incomplete examples break agent triggering accuracy

> **Automated audit**: Found by NLPM self-audit.

## Changes
Added `user: "/nlpm:check"` to the first example block