### PR TITLE
fix: add missing name field to agent/command frontmatter

### DIFF
--- a/agents/checker.md
+++ b/agents/checker.md
@@ -1,4 +1,5 @@
 ---
+name: checker
 description: |
   Cross-component consistency analyzer for NL programming artifacts. Checks reference integrity, detects orphans, finds behavioral contradictions, and identifies terminology drift across plugin components.
 

--- a/agents/scanner.md
+++ b/agents/scanner.md
@@ -1,4 +1,5 @@
 ---
+name: scanner
 description: |
   Discover and classify all NL programming artifacts in a repository.
   <example>

--- a/agents/scorer.md
+++ b/agents/scorer.md
@@ -1,4 +1,5 @@
 ---
+name: scorer
 description: |
   Scores NL programming artifacts on a 100-point scale using deterministic penalties. Use this agent when scoring plugin components, checking artifact quality, or running quality analysis on commands, agents, skills, rules, hooks, or CLAUDE.md.
 

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -1,4 +1,5 @@
 ---
+name: tester
 description: |
   Evaluate NL artifacts against test specifications. Predicts trigger accuracy, checks output format expectations, validates frontmatter, and scores against thresholds.
   <example>

--- a/agents/vague-scanner.md
+++ b/agents/vague-scanner.md
@@ -1,4 +1,5 @@
 ---
+name: vague-scanner
 description: |
   Mechanical scanner for vague quantifier words in NL artifacts. Counts occurrences of flagged words and reports exact locations. Use this agent for fast, deterministic vague-word counting before the scorer applies judgment.
 

--- a/commands/check.md
+++ b/commands/check.md
@@ -1,4 +1,5 @@
 ---
+name: check
 description: "Check cross-component consistency — reference integrity, orphans, contradictions"
 argument-hint: "[path]"
 allowed-tools: Read, Glob, Grep, Task

--- a/commands/fix.md
+++ b/commands/fix.md
@@ -1,4 +1,5 @@
 ---
+name: fix
 description: "Auto-fix fixable issues in NL artifacts — missing fields, heading gaps, field renames"
 argument-hint: "[path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Task

--- a/commands/init.md
+++ b/commands/init.md
@@ -1,4 +1,5 @@
 ---
+name: init
 description: "Initialize NLPM for this project — detect artifacts, set lint strictness"
 allowed-tools: Read, Write, Glob, AskUserQuestion
 ---

--- a/commands/ls.md
+++ b/commands/ls.md
@@ -1,4 +1,5 @@
 ---
+name: ls
 description: "Discover and inventory all natural language programming artifacts in a repository"
 argument-hint: "[repo-path]"
 allowed-tools: Read, Glob, Grep, Task

--- a/commands/score.md
+++ b/commands/score.md
@@ -1,4 +1,5 @@
 ---
+name: score
 description: "Score NL programming artifacts — 100-point quality analysis per file"
 argument-hint: "[path]"
 allowed-tools: Read, Glob, Grep, Bash, Task

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,4 +1,5 @@
 ---
+name: test
 description: "Run NL artifact tests — evaluate artifacts against .nlpm-test/*.spec.md specifications (TDD for natural language programming)"
 argument-hint: "[spec-path]"
 allowed-tools: Read, Glob, Grep, Task

--- a/commands/trend.md
+++ b/commands/trend.md
@@ -1,4 +1,5 @@
 ---
+name: trend
 description: "Show quality score trends over time — track improvements, detect degradation"
 argument-hint: "[path]"
 allowed-tools: Read, Write, Glob, Task


### PR DESCRIPTION
## Summary
Add missing `name` field to all agent and command frontmatter for proper registration.

> **Automated audit**: Found by [NLPM](https://github.com/xiaolai/nlpm-for-claude) auditor pipeline (round 2 compliance scan).