### PR TITLE
multi-tool foundation: design doc + Tier 2-Claude/Codex/Antigravity detection

### DIFF
--- a/agents/scorer.md
+++ b/agents/scorer.md
@@ -70,13 +70,16 @@ categories. Before reporting any finding, run this 5-step check:
      is required per `nlpm:conventions` §2; primary source:
      <https://code.claude.com/docs/en/slash-commands>)
 
-3. **Path scope check** — three tiers, evaluated in this order:
+3. **Path scope check** — multi-tier classification, evaluated in this order.
+   See `analysis/multi-tool-design-2026-05.md` for the design rationale and
+   the PR-A / PR-B / PR-C staging plan.
 
    **Tier 1 — Cross-tool SKILL.md (open spec at agentskills.io).** SKILL.md
    files at tool-namespaced paths are scored against the universal Agent
-   Skills spec; do NOT apply Claude-Code-specific overlays:
+   Skills spec; do NOT apply any tool-specific overlays:
    - `.codex/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md`
    - `.continue/skills/`, `.cursor/skills/`, `.kiro/skills/`, `.gemini/skills/`
+   - `<workspace>/.agent/skills/` (Antigravity-specific, singular)
    - Any `<tool>/skills/<name>/SKILL.md` layout
    These ARE skill paths — score them per the open spec (only `name` and
    `description` required; `license`, `compatibility`, `metadata`,
@@ -85,25 +88,78 @@ categories. Before reporting any finding, run this 5-step check:
 
    **Tier 1.5 — Open-spec corpora at the Tier 2 glob (added 2026-05-25,
    audit: google/skills).** When a SKILL.md matches the Tier 2 glob
-   `skills/**/SKILL.md` BUT the repo root has none of these Claude-Code
-   markers — `.claude/` directory, `.claude-plugin/plugin.json`,
-   `CLAUDE.md`, `hooks/hooks.json`, `commands/` directory, `agents/`
-   directory — treat the file as **Tier 1** (open Agent Skills spec only).
-   This handles first-party open-spec publications such as `google/skills`,
-   `android/skills`, and `google-gemini/gemini-skills`, which live at
-   `skills/<category>/<name>/SKILL.md` with no surrounding plugin
-   scaffolding. Applying the Tier 2 Claude-Code overlay to these repos
-   would over-penalize them for missing `## Output`, `version:`, and
-   `model:` fields that the open spec does not require. Detection is
-   deterministic: a single directory-existence check on the repo root.
+   `skills/**/SKILL.md` BUT the repo root has none of these markers from
+   ANY of the supported tools (see Tier 2-Claude / 2-Codex / 2-Antigravity
+   marker lists below), treat the file as **Tier 1** (open Agent Skills
+   spec only). This handles first-party open-spec publications such as
+   `google/skills`, `android/skills`, and `google-gemini/gemini-skills`,
+   which live at `skills/<category>/<name>/SKILL.md` with no surrounding
+   plugin scaffolding. Applying a tool-specific overlay would over-penalize
+   them for fields the open spec does not require. Detection is
+   deterministic: a multi-marker directory/file existence check on the
+   repo root.
 
-   **Tier 2 — Claude Code-specific paths.** Apply both spec-level checks
-   AND Claude Code conventions:
+   **Tier 2-Claude — Claude Code project.** Markers (presence of ANY):
+   `.claude/` directory, `.claude-plugin/plugin.json`,
+   `.claude-plugin/marketplace.json`, `CLAUDE.md`, `hooks/hooks.json`.
+   Artifact paths scored under this overlay:
    - `.claude/commands/**/*.md`, `commands/**/*.md`
    - `.claude/agents/**/*.md`, `agents/**/*.md`
    - `.claude/skills/**/SKILL.md`, `skills/**/SKILL.md`
    - `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
    - `hooks/hooks.json`, `.mcp.json`, `CLAUDE.md`
+   - `.claude/rules/**/*.md`, `.claude/settings.json`, `.lsp.json`,
+     `monitors/monitors.json`
+   Apply both spec-level checks AND Claude Code conventions. Loads
+   `nlpm:conventions` and (after PR-B lands) `nlpm:conventions-claude`.
+
+   **Tier 2-Codex — Codex CLI project (added 2026-05-25, PR-A).**
+   Markers (presence of ANY): `.codex/config.toml`, `.codex/hooks.json`,
+   `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`,
+   `AGENTS.md` at repo root with no other tool markers present, or
+   `~/.codex/prompts/` references in the repo. Artifact paths scored
+   under this overlay:
+   - `.agents/skills/<name>/SKILL.md` (cross-tool surface)
+   - `.codex/config.toml`, `.codex/hooks.json`
+   - `.codex-plugin/plugin.json`
+   - `.agents/plugins/marketplace.json`
+   - `AGENTS.md` (hierarchical, root-down)
+   - `agents/openai.yaml` sidecars next to SKILL.md files
+   **PR-A staging:** Tier 2-Codex DETECTION works; the matching
+   `nlpm:conventions-codex` overlay does not yet exist. Until PR-B,
+   Codex-shaped repos score at the universal floor (open spec only)
+   for skill content, and Codex-specific artifacts (config.toml,
+   hooks.json, plugin.json, marketplace.json) are silently skipped
+   rather than scored against a missing rubric. This is correct
+   "detected but not yet rubricized" behavior — same shape as Tier 1.5.
+
+   **Tier 2-Antigravity — Antigravity / Gemini-lineage project (added
+   2026-05-25, PR-A).** Markers (presence of ANY): `.gemini/`, `.agent/`
+   (singular, Antigravity-specific), `gemini-extension.json`, `GEMINI.md`,
+   `~/.gemini/extensions/` references, `<workspace>/.agent/skills/`.
+   Artifact paths scored under this overlay:
+   - `.gemini/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md`,
+     `<workspace>/.agent/skills/<name>/SKILL.md`
+   - `.gemini/commands/<name>.toml` (TOML format with
+     `{{args}}`/`!{...}`/`@{path}` template syntax)
+   - `.gemini/settings.json` (hooks + MCP servers embedded)
+   - `gemini-extension.json`
+   - `GEMINI.md` (hierarchical with `@file.md` imports)
+   **PR-A staging:** Same as Tier 2-Codex — detection works, overlay
+   `nlpm:conventions-antigravity` does not yet exist; universal floor
+   only until PR-B. Additional caveat: Antigravity 2.0 launched
+   2026-05-19; the directory layout is still settling (singular
+   `.agent/` vs plural `.agents/` cross-tool alias). Defer
+   Antigravity-specific scoring until the spec stabilizes (PR-B
+   trigger conditions documented in the design doc).
+
+   **Multi-tool repos.** When a repo has markers for more than one
+   tool (e.g., nlpm itself ships as both a Claude plugin AND a Codex
+   plugin), classify each artifact by its path — `.claude/*` artifacts
+   under Tier 2-Claude, `.codex/*` artifacts under Tier 2-Codex,
+   `.agents/skills/<name>/SKILL.md` under Tier 1 (open-spec surface
+   shared across tools). The repo does not get one tier; each artifact
+   gets one tier based on its path.
 
    Files outside all tiers (e.g., `.cursorrules`, `.opencode/commands/`)
    follow tool-specific non-skill schemas — drop the finding silently.

--- a/analysis/multi-tool-design-2026-05.md
+++ b/analysis/multi-tool-design-2026-05.md
@@ -1,0 +1,153 @@
+# Multi-Tool Design — nlpm Beyond Claude Code
+
+**Status:** design proposal, 2026-05-25
+**Context:** repo rename `nlpm-for-claude` → `nlpm`; expand audit surface to Claude Code + Codex CLI + Antigravity (which absorbs Gemini CLI on 2026-06-18).
+
+This document records the six decisions taken to expand nlpm beyond Claude Code, the research that informed them, and the staged execution plan.
+
+---
+
+## Six decisions
+
+### 1. Sub-skill split — split `nlpm:conventions` into four skills
+
+```
+skills/nlpm/
+  conventions/SKILL.md              # universal: SKILL.md open spec, AGENTS.md, vague-quantifier R01, R51 vocab
+  conventions-claude/SKILL.md       # Claude Code overlay: .claude/* paths, plugin.json, CLAUDE.md, hook events, LSP, monitors
+  conventions-codex/SKILL.md        # Codex CLI overlay: .codex/* + .agents/* paths, config.toml, hook events, marketplace
+  conventions-antigravity/SKILL.md  # Antigravity overlay: .gemini/* (legacy), .agent/* (new), gemini-extension.json, GEMINI.md
+```
+
+The scorer's Tier 1.5 already separates open-spec corpora from Claude-overlay corpora. Tier 2 expands to Tier 2-Claude / Tier 2-Codex / Tier 2-Antigravity, each loading its own overlay on top of the universal floor. Tier 1.5 loads only the universal skill.
+
+**Rejected alternative:** keep one fat `nlpm:conventions` skill with per-tool subsections. Cleaner to maintain but every audit loads every tool's knowledge — a Tier-1.5 audit of `google/skills` would pay for ~3× the tokens it needs. Sub-skill split makes the retrieval surface match the audit shape.
+
+### 2. Repo rename — `nlpm` (no org change, no namespace prefix)
+
+`github.com/xiaolai/nlpm-for-claude` → `github.com/xiaolai/nlpm`. Plugin name in `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` stays `nlpm`. Marketplace entries in both Claude and Codex marketplaces update to point to the new repo URL.
+
+**Rejected alternatives:**
+- `nlpm-multi` / `nlpm-multitool`: redundant after the rename — multi-tool support becomes the default state, not a distinguishing feature.
+- Move under a new org: `nlpm` doesn't have collisions worth working around; the personal-account path is fine.
+
+### 3. Antigravity scope — staged adoption
+
+Antigravity 2.0 launched at Google I/O 2026 (2026-05-19), six days before this document. The directory layout is still in flux (two authoritative research passes disagreed on `<workspace>/.agent/skills/` singular vs `.agents/skills/` plural). Hook and plugin specs reference "not yet 1:1 parity" with Gemini CLI without enumerating gaps.
+
+Auditing against an unsettled spec produces wrong findings — same anti-pattern as the prior `BUG-broken-reference` low-landing-rate suppression case (`rule-health.py`).
+
+**Staged plan:**
+- **Phase A (PR-A, now):** Tier 2-Antigravity detection — repo-shape classifier recognizes `.gemini/`, `.agent/`, `gemini-extension.json`, `GEMINI.md`. Score the universal floor (SKILL.md open spec + AGENTS.md if present). Do NOT score Antigravity-specific hook/plugin artifacts yet.
+- **Phase B (PR-B+, after Antigravity 2.1 or equivalent stabilization):** Add Antigravity-specific penalty tables. Trigger: official Antigravity directory-layout spec published, OR Antigravity overtakes Gemini CLI in real-world repo count (whichever comes first).
+
+This preserves the discover→audit→learn loop on Antigravity repos without filing PRs against unstable conventions.
+
+### 4. Hook events — per-tool tables, no translation
+
+The three event vocabularies are not 1:1-mappable:
+
+| Position | Claude Code | Codex CLI | Antigravity (Gemini lineage) |
+|---|---|---|---|
+| Session boundary | `SessionStart`, `SessionEnd` | `SessionStart` (no end) | `SessionStart`, `SessionEnd` |
+| User input | `UserPromptSubmit` | `UserPromptSubmit` | — |
+| Pre-tool | `PreToolUse` | `PreToolUse` | `BeforeTool`, `BeforeToolSelection` (split) |
+| Post-tool | `PostToolUse` | `PostToolUse` | `AfterTool` |
+| Model | — | — | `BeforeModel`, `AfterModel` |
+| Agent boundary | — | `SubagentStart`, `SubagentStop` | `BeforeAgent`, `AfterAgent` |
+| Compaction | `PreCompact` | `PreCompact`, `PostCompact` | `PreCompress` |
+| Permission | `PermissionRequest` | `PermissionRequest` | — |
+| Stop | `Stop`, `StopFailure`, `SubagentStop` | `Stop`, `SubagentStop` | — |
+| Notification | `Notification`, `FileChanged` | — | `Notification` |
+
+Gemini/Antigravity's `BeforeModel` vs `BeforeToolSelection` distinction has no analog in Claude or Codex — both happen during a Claude/Codex `PreToolUse`. Forcing a universal taxonomy would either collapse the distinction (losing audit precision) or invent shim events that don't exist (false complexity).
+
+**Decision:** `nlpm:scoring` ships three Hooks penalty tables, one per tool, plus a small "shared event names" reference for the events that do appear in multiple tools. No universal-event-name layer.
+
+**Rejected alternative:** Build a `nlpm:hooks` universal taxonomy with canonical buckets (`pre_tool`, `post_tool`, `session_start`, etc.). Would enable cross-tool rules like "every plugin should define at least one `pre_tool` hook" — but those rules don't survive the lifecycle-model divergence and would produce noise.
+
+### 5. AGENTS.md as canonical universal memory
+
+- **Codex CLI:** reads `AGENTS.md` natively; default 32 KiB cap; hierarchical (root → cwd, closer overrides earlier); `~/.codex/AGENTS.override.md` for personal overlays.
+- **Antigravity (Gemini lineage):** reads `GEMINI.md` natively; `context.fileName` setting accepts an array — set to `["AGENTS.md", "GEMINI.md"]` to read both. Hierarchical + `@file.md` imports.
+- **Claude Code:** reads `CLAUDE.md` natively; supports `@AGENTS.md` import syntax (this is how nlpm itself already works — `CLAUDE.md` is one line: `@AGENTS.md`).
+
+AGENTS.md is the only one of the three that all three tools can be made to read with no per-tool fork. Promoting it as the canonical universal memory file:
+
+- nlpm's own conventions skill recommends `AGENTS.md` as the primary instructions file.
+- `CLAUDE.md` and `GEMINI.md` become `@AGENTS.md` import shims when the project targets multiple tools.
+- The auditor (PR-C) recognizes any of the three but prefers `AGENTS.md` presence as the marker of a tool-agnostic project.
+
+**Rejected alternative:** Treat all three as equal canonical paths and let projects pick. Produces ecosystem fragmentation where Claude-only projects use CLAUDE.md, Codex-only projects use AGENTS.md, multi-tool projects use whatever the author favored. AGENTS.md as canonical gives a default that costs Claude Code authors nothing (one-line shim) and costs Codex authors nothing (it's already native).
+
+### 6. Gemini CLI → Antigravity — one overlay, label legacy paths inside
+
+Gemini CLI sunsets 2026-06-18 (24 days from this doc). Both reports confirmed: artifact shapes survive the transition. Differences are CLI name, directory naming, and the "extensions" → "Antigravity plugins" rename.
+
+**Decision:** one `nlpm:conventions-antigravity` skill that documents both:
+
+- **Legacy (until 2026-06-18 sunset):** `.gemini/`, `gemini-extension.json`, `GEMINI.md`, `gemini extensions install`, `~/.gemini/skills/`
+- **New:** `<workspace>/.agent/skills/` (Antigravity-specific singular) AND `.agents/skills/` (cross-tool alias, also used by Codex), `~/.gemini/antigravity/skills/` (transitional global path), `npx skills add` (cross-tool installer)
+
+The skill's scope note explicitly flags the transition window and the directory-layout uncertainty. PR-B will update once Antigravity publishes a stable directory spec.
+
+**Rejected alternative:** Two overlays (`conventions-gemini` + `conventions-antigravity`) until 2026-06-18, then delete the Gemini one. Adds maintenance burden for a 24-day window; the two would be ~80% identical anyway.
+
+---
+
+## Staged execution plan
+
+### PR-A (this PR) — Foundation
+
+- **NEW:** `analysis/multi-tool-design-2026-05.md` (this document)
+- **MODIFIED:** `agents/scorer.md` — extend Tier 2 into Tier 2-Claude / Tier 2-Codex / Tier 2-Antigravity (detection rules; overlay loading is forward-referenced to PR-B's sub-skills)
+- **MODIFIED:** `skills/nlpm/scoring/SKILL.md` — Scope Note cross-references this design doc; flags PR-B's coming changes
+
+Scope discipline: PR-A makes no content move. Existing audits continue to score Claude-shaped repos identically. The new Tier 2-X classifiers detect their respective ecosystems but fall back to the universal floor when their overlay skill doesn't exist yet — equivalent to Tier 1.5 behavior until PR-B.
+
+### PR-B — Content migration + scoring tables
+
+- **NEW:** `skills/nlpm/conventions-claude/SKILL.md` (move Claude-specific content out of `conventions/SKILL.md`)
+- **NEW:** `skills/nlpm/conventions-codex/SKILL.md` (write from Codex research report)
+- **NEW:** `skills/nlpm/conventions-antigravity/SKILL.md` (write from Antigravity + Gemini research reports; flag uncertainty)
+- **MODIFIED:** `skills/nlpm/conventions/SKILL.md` — slim down to universal floor (SKILL.md open spec, AGENTS.md conventions, vocabulary registry, vague-quantifier list)
+- **MODIFIED:** `skills/nlpm/scoring/SKILL.md` — split Hooks table into three per-tool tables; add new artifact-type rows for `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `gemini-extension.json`, `agents/openai.yaml` sidecar, LSP, Monitors, and new Claude SKILL.md fields (`context`, `agent`, `paths`, `hooks`, etc.)
+- **MODIFIED:** `agents/scorer.md` — Tier 2-X each loads its matching overlay; remove the "forward-reference to overlay not-yet-existing" stub from PR-A
+- **MODIFIED:** `agents/checker.md` — cross-component references need to recognize Codex's `.agents/plugins/marketplace.json` and Antigravity's extension manifests
+- **MODIFIED:** `bin/nlpm-check` — universal-floor validators only (the deterministic core); per-tool validators stay LLM-judged in scorer
+
+### PR-C — Auditor pipeline + repo rename
+
+- **MODIFIED:** `auditor-discover.yml` — three parallel `gh search repos` queries: Claude-shaped, Codex-shaped, Antigravity-shaped. Single registry, `repo_type` field added.
+- **MODIFIED:** `auditor/scripts/vendor_default_filter.py` — add OpenAI-CLA check (Codex contributions need their own contributor agreement — research before merging).
+- **MODIFIED:** `agents/security-scanner.md` — recognize Codex MCP TOML format and Antigravity hook events as executable surfaces.
+- **MODIFIED:** `auditor/exemplars/` — exemplar frontmatter gains a `tool:` field (claude / codex / antigravity / open-spec). `build-exemplar-gallery.py` adds a per-tool view.
+- **NEW:** Per-tool rule-health metrics in `auditor/scripts/rule-health.py` — track precision per (rule, tool) instead of per rule.
+- **MODIFIED:** `.claude-plugin/plugin.json` + `.codex-plugin/plugin.json` — bump major version; update `name` if needed.
+- **MODIFIED:** central marketplace (`xiaolai/claude-plugin-marketplace`) — update `nlpm` entry to new repo URL in both `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`.
+- **MODIFIED:** README files, site (`site/index.md`, `site/install.md`), `bin/nlpm-build-reference-md` output paths.
+- **External:** GitHub repo rename (preserves stars, issues, PRs via auto-redirect); update remote references in local clones.
+
+### What stays Claude-Code-specific permanently
+
+A few nlpm artifacts are slash-command surfaces that only run inside Claude Code:
+
+- `commands/*.md` — `/nlpm:*` slash commands. These are Claude Code commands; the equivalent Codex/Antigravity surface uses skills.
+- `hooks/hooks.json` — Claude Code hook config.
+- The `auditor/` GitHub Actions workflows — they invoke `claude-code-action`. Codex has its own action surface; Antigravity has the SDK + Managed Agents.
+
+These remain Claude-only artifacts of the nlpm plugin itself; the rules nlpm enforces become multi-tool, but the delivery vehicle for the slash commands is still a Claude Code plugin. The `bin/nlpm-check` standalone binary (already pure Python stdlib) covers the cross-tool author surface for users not running Claude Code.
+
+---
+
+## Open uncertainties
+
+These need verification before PR-B lands:
+
+1. **Antigravity directory layout** — `.agent/skills/` (Antigravity report) vs `.agents/skills/` (Gemini report cross-tool alias). Resolution: probably both are true (Antigravity-specific singular + cross-tool plural alias) but the codelab is the only authoritative source and it pre-dates Antigravity 2.0 by months.
+2. **`npx skills` verb** — `add` (Antigravity codelab) vs `install` (Cloud Next announcement). Both terms appear; repo page says `add`. PR-B should cite `add` and note `install` as a legacy term.
+3. **Codex OpenAI CLA policy** — does contributing to `openai/codex`-adjacent repos require a signed CLA the way Google orgs do? The contribute pipeline's policy gates need to know before PR-C scales discovery to Codex-shaped repos.
+4. **Antigravity `child_agents_md` feature flag** — referenced in Codex's `agents_md.md` but semantics not fully documented. Codex-side concern, not Antigravity, but the AGENTS.md hierarchy story interacts.
+5. **Claude Code `.lsp.json` and `monitors/monitors.json`** — schemas not researched in this round. PR-B adds nlpm:scoring rows for both but the schemas need their own pass.
+
+These are recorded here so the next research turn knows where to dig.

--- a/skills/nlpm/scoring/SKILL.md
+++ b/skills/nlpm/scoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scoring
 description: "Use when scoring NL artifact quality, applying penalties, or calibrating lint judgment — contains the 100-point rubric with penalty tables per artifact type and 4 worked calibration examples."
-version: 0.2.0
+version: 0.2.1
 ---
 
 # NLPM Quality Scoring Rubric
@@ -399,9 +399,13 @@ Total penalties: -59
 ## Scope Note
 
 This skill covers the NLPM scoring formula, penalty tables, score bands, and calibration examples. It does NOT cover:
-- Artifact schemas and valid field values → see `nlpm:conventions`
+- Artifact schemas and valid field values → see `nlpm:conventions` (universal) and the tool-specific overlays `nlpm:conventions-claude`, `nlpm:conventions-codex`, `nlpm:conventions-antigravity` (the latter three created in PR-B; see `analysis/multi-tool-design-2026-05.md`)
 - Patterns and anti-patterns catalog → see `nlpm:patterns`
 - How to run the score command → see `commands/score.md`
+
+### Multi-tool scoring (in progress, 2026-05-25)
+
+nlpm is moving from Claude-Code-only to multi-tool coverage (Claude Code + Codex CLI + Antigravity). The Tier classification in `agents/scorer.md` already separates open-spec, Tier 1.5 open-spec corpora, and Tier 2 per-tool overlays (2-Claude / 2-Codex / 2-Antigravity). PR-B will split the Hooks penalty table into per-tool tables (the three tools' event vocabularies are not 1:1-mappable, by design — see the design doc) and add new rows for `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `gemini-extension.json`, `agents/openai.yaml` sidecars, LSP, Monitors, and new Claude SKILL.md fields (`context: fork`, `agent:`, `paths:` glob scoping, skill-scoped `hooks:`, etc.). Until PR-B lands, Tier 2-Codex and Tier 2-Antigravity artifacts are detected but scored at the universal floor only.
 
 ### Known False Positive Patterns
 


### PR DESCRIPTION
## Summary

**PR-A of three** in the nlpm de-Claude-ification arc. Sets the structural foundation for expanding nlpm beyond Claude Code to also cover Codex CLI and Antigravity (which absorbs Gemini CLI on 2026-06-18). No content has moved yet — that's PR-B.

See \`analysis/multi-tool-design-2026-05.md\` for the full design rationale and the three-PR staging plan.

## Six decisions taken

1. **Sub-skill split** — \`nlpm:conventions\` will split into 4 skills (universal + 3 per-tool overlays). PR-B does the move.
2. **Rename target** — \`nlpm\` (no org change, no prefix). PR-C executes.
3. **Antigravity scope** — staged. Detect now, defer deep audit (the spec is 6 days old and the \`.agent/\` vs \`.agents/\` inconsistency between authoritative sources is unresolved).
4. **Hook events** — per-tool tables, no universal translation. Gemini's \`BeforeModel\` vs \`BeforeToolSelection\` has no 1:1 mapping to Claude/Codex \`PreToolUse\`.
5. **AGENTS.md** — canonical universal memory file (Codex native, Gemini-configurable, Claude via \`@AGENTS.md\` — already how nlpm itself works).
6. **Gemini → Antigravity** — one overlay, label legacy paths inside. Gemini CLI sunsets 2026-06-18 (24 days); maintaining two overlays for that window is busywork.

## What this PR changes

### \`agents/scorer.md\` — Tier expansion

Tier classification grows from 3 (Tier 1 / 1.5 / 2-Claude) to 5 (Tier 1 / 1.5 / 2-Claude / 2-Codex / 2-Antigravity).

- **Tier 2-Codex markers:** \`.codex/config.toml\`, \`.codex-plugin/plugin.json\`, \`.agents/plugins/marketplace.json\`, root \`AGENTS.md\`.
- **Tier 2-Antigravity markers:** \`.gemini/\`, \`.agent/\` (singular, Antigravity-specific), \`gemini-extension.json\`, \`GEMINI.md\`.
- **Tier 1.5 marker check** extends to recognize ALL tools' markers — an open-spec corpus with a \`GEMINI.md\` still scores as Tier 1.5 (universal floor) rather than misclassified.
- **Multi-tool repos** (nlpm itself is one): each artifact classified by path, not the repo as a whole.

### PR-A staging discipline

Tier 2-Codex and Tier 2-Antigravity **detection works**; the matching \`nlpm:conventions-codex\` / \`nlpm:conventions-antigravity\` overlays **don't exist yet** (PR-B creates them). Until PR-B, those tiers score at the universal floor — same fail-safe shape as Tier 1.5. No false-positive flood, no over-penalization, no breakage of existing Claude-shaped audits.

### \`skills/nlpm/scoring/SKILL.md\`

Scope Note adds the multi-tool roadmap section pointing to the design doc. Cross-references the four conventions sub-skills (existing + 3 PR-B). Version bump 0.2.0 → 0.2.1 (doc-only).

### \`analysis/multi-tool-design-2026-05.md\` (new)

The full design doc: rationale for the six decisions, gap matrix (artifact-type × ecosystem), execution plan for PR-A / PR-B / PR-C, and open uncertainties flagged for PR-B verification.

## Backward compatibility

**Zero behavioral change for existing audits.** Claude-shaped repos continue to score identically. Codex-shaped and Antigravity-shaped repos that were previously misclassified as Tier 2-Claude (and over-penalized for missing CLAUDE.md, missing \`.claude-plugin/plugin.json\`, etc.) now correctly classify as their own tier and fall back to the universal floor instead.

## Validation

- \`python3 -m unittest tests.test_nlpm_check\` — 23/23 pass.
- No content move; no scoring-rule edits to penalty tables. Only the path-scope classifier changed.
- The classifier is deterministic — file/directory existence checks only.

## What comes next

| PR | Scope | Risk |
|---|---|---|
| **PR-B** | Conventions skill split (4 skills) + scoring table updates (per-tool hook tables, new artifact rows) | Medium — content migration |
| **PR-C** | Auditor pipeline multi-tool discovery + repo rename (\`nlpm-for-claude\` → \`nlpm\`) | High — coordinated marketplace updates |

## Test plan

- [ ] Confirm next audit on a Codex-shaped repo (e.g., something with \`.codex-plugin/plugin.json\`) correctly classifies as Tier 2-Codex and falls back to universal floor scoring (no Claude-overlay false positives).
- [ ] Confirm next audit on \`google/skills\` (Tier 1.5) still passes — the expanded marker check shouldn't change Tier 1.5 behavior for repos that have no tool markers.
- [ ] Confirm next audit on nlpm itself (multi-tool repo — has both \`.claude/\` and \`.codex/\`) classifies each artifact by path, not the repo wholesale.