### PR TITLE
multi-tool PR-B: conventions split + per-tool hook tables + new artifact rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ Each command does one thing -- no flags (except `--changed` on score).
 ## Agents
 
 - agents/scanner.md -- haiku, mechanical file discovery
-- agents/scorer.md -- sonnet, 100-point quality scoring (skills: scoring, conventions)
-- agents/checker.md -- sonnet, cross-component consistency (skills: conventions)
+- agents/scorer.md -- sonnet, 100-point quality scoring (skills: scoring, conventions, conventions-claude, conventions-codex, conventions-antigravity, vocabulary)
+- agents/checker.md -- sonnet, cross-component consistency (skills: conventions, conventions-claude, conventions-codex, conventions-antigravity, vocabulary)
 - agents/vague-scanner.md -- haiku, mechanical vague-word counting (no skills)
 - agents/tester.md -- sonnet, evaluates artifacts against test specs (skills: testing, conventions, scoring)
 - agents/security-scanner.md -- sonnet, security risk detection in executable artifacts (skills: security)
@@ -41,7 +41,10 @@ Each command does one thing -- no flags (except `--changed` on score).
 ## Skills
 
 ### Auto-loaded by agents (declared in agent frontmatter `skills:`)
-- skills/nlpm/conventions/ -- Claude Code schemas, hook events, naming patterns -- loaded by scanner, scorer, checker, tester
+- skills/nlpm/conventions/ -- Universal NL artifact conventions: SKILL.md open spec, AGENTS.md as canonical universal memory, vague-quantifier list, prompt engineering, naming, override system. Loaded by scanner, scorer, checker, tester.
+- skills/nlpm/conventions-claude/ -- Claude Code overlay: .claude/* paths, plugin.json, hook events, hooks.json, CLAUDE.md, LSP, monitors, settings, tool catalog. Loaded by scorer, checker for Tier 2-Claude artifacts.
+- skills/nlpm/conventions-codex/ -- Codex CLI overlay: .codex/config.toml, .codex-plugin/plugin.json, .agents/skills/ layout, AGENTS.md hierarchy, agents/openai.yaml sidecar, Codex hook events, marketplace. Loaded by scorer, checker for Tier 2-Codex artifacts.
+- skills/nlpm/conventions-antigravity/ -- Antigravity + legacy Gemini CLI overlay: .gemini/* paths, .agent/ workspace skills, gemini-extension.json, GEMINI.md, TOML slash commands, Gemini-lineage hook events. Advisory-only for Antigravity-specific artifacts until spec stabilizes. Loaded by scorer, checker for Tier 2-Antigravity artifacts.
 - skills/nlpm/scoring/ -- penalty tables with rule number cross-references -- loaded by scorer, tester
 - skills/nlpm/testing/ -- NL-TDD spec format, test patterns -- loaded by tester
 - skills/nlpm/security/ -- security pattern database for executable artifact scanning -- loaded by security-scanner

--- a/agents/checker.md
+++ b/agents/checker.md
@@ -17,6 +17,9 @@ color: cyan
 tools: Read, Glob, Grep
 skills:
   - nlpm:conventions
+  - nlpm:conventions-claude
+  - nlpm:conventions-codex
+  - nlpm:conventions-antigravity
   - nlpm:vocabulary
 ---
 

--- a/agents/scorer.md
+++ b/agents/scorer.md
@@ -21,6 +21,9 @@ tools: Read, Glob, Grep
 skills:
   - nlpm:scoring
   - nlpm:conventions
+  - nlpm:conventions-claude
+  - nlpm:conventions-codex
+  - nlpm:conventions-antigravity
   - nlpm:vocabulary
 ---
 
@@ -111,7 +114,10 @@ categories. Before reporting any finding, run this 5-step check:
    - `.claude/rules/**/*.md`, `.claude/settings.json`, `.lsp.json`,
      `monitors/monitors.json`
    Apply both spec-level checks AND Claude Code conventions. Loads
-   `nlpm:conventions` and (after PR-B lands) `nlpm:conventions-claude`.
+   `nlpm:conventions` (universal floor) and `nlpm:conventions-claude`
+   (PR-B landed the Claude overlay, including new v2.1.x fields:
+   `context: fork`, `agent:`, `paths:` glob scoping, skill-scoped
+   `hooks:`, the merged commands/skills surface, LSP, monitors).
 
    **Tier 2-Codex — Codex CLI project (added 2026-05-25, PR-A).**
    Markers (presence of ANY): `.codex/config.toml`, `.codex/hooks.json`,
@@ -125,13 +131,11 @@ categories. Before reporting any finding, run this 5-step check:
    - `.agents/plugins/marketplace.json`
    - `AGENTS.md` (hierarchical, root-down)
    - `agents/openai.yaml` sidecars next to SKILL.md files
-   **PR-A staging:** Tier 2-Codex DETECTION works; the matching
-   `nlpm:conventions-codex` overlay does not yet exist. Until PR-B,
-   Codex-shaped repos score at the universal floor (open spec only)
-   for skill content, and Codex-specific artifacts (config.toml,
-   hooks.json, plugin.json, marketplace.json) are silently skipped
-   rather than scored against a missing rubric. This is correct
-   "detected but not yet rubricized" behavior — same shape as Tier 1.5.
+   Loads `nlpm:conventions` and `nlpm:conventions-codex` (PR-B landed
+   the Codex overlay). The overlay covers .codex/config.toml TOML
+   schema, .codex-plugin/plugin.json manifest, .agents/plugins/marketplace.json
+   schema, agents/openai.yaml sidecar conventions, Codex hook event
+   set, and AGENTS.md hierarchy.
 
    **Tier 2-Antigravity — Antigravity / Gemini-lineage project (added
    2026-05-25, PR-A).** Markers (presence of ANY): `.gemini/`, `.agent/`
@@ -145,13 +149,13 @@ categories. Before reporting any finding, run this 5-step check:
    - `.gemini/settings.json` (hooks + MCP servers embedded)
    - `gemini-extension.json`
    - `GEMINI.md` (hierarchical with `@file.md` imports)
-   **PR-A staging:** Same as Tier 2-Codex — detection works, overlay
-   `nlpm:conventions-antigravity` does not yet exist; universal floor
-   only until PR-B. Additional caveat: Antigravity 2.0 launched
-   2026-05-19; the directory layout is still settling (singular
-   `.agent/` vs plural `.agents/` cross-tool alias). Defer
-   Antigravity-specific scoring until the spec stabilizes (PR-B
-   trigger conditions documented in the design doc).
+   Loads `nlpm:conventions` and `nlpm:conventions-antigravity` (PR-B
+   landed the Antigravity overlay). **The overlay is advisory-only** for
+   Antigravity-specific artifacts — the spec is unsettled (Antigravity 2.0
+   launched 2026-05-19; singular `.agent/` vs plural `.agents/` is
+   unresolved). Score the universal floor with confidence; treat
+   Antigravity-specific hook/plugin findings as advisory and confidence:low
+   until the directory-layout spec stabilizes.
 
    **Multi-tool repos.** When a repo has markers for more than one
    tool (e.g., nlpm itself ships as both a Claude plugin AND a Codex

--- a/skills/nlpm/conventions-antigravity/SKILL.md
+++ b/skills/nlpm/conventions-antigravity/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: conventions-antigravity
+description: "Use when scoring or writing Antigravity (or legacy Gemini CLI) artifacts — covers .gemini/ paths, .agent/ workspace skills, gemini-extension.json, GEMINI.md, TOML slash commands, Gemini-lineage hook events. Spec is unsettled (Antigravity 2.0 launched 2026-05-19); many checks are advisory until PR-B verification."
+version: 0.1.0
+---
+
+# Antigravity Conventions (with Gemini CLI legacy)
+
+Tool-specific overlay for Google Antigravity CLI artifacts, including legacy Gemini CLI paths during the transition window. Loaded by the scorer and checker when an artifact is classified as **Tier 2-Antigravity** (per `agents/scorer.md` step 3). The universal floor lives in `nlpm:conventions`.
+
+**Status:** Antigravity 2.0 was announced at Google I/O 2026 on **2026-05-19** (six days before this file was written). The directory layout is still settling, the official Antigravity-specific spec doc is sparse, and two authoritative research passes disagreed on `.agent/` (singular) vs `.agents/` (plural) as the canonical skills path. This skill is **advisory-only** for Antigravity-specific artifacts. PR-B verification trigger conditions are recorded in `analysis/multi-tool-design-2026-05.md`.
+
+**Transition timeline:**
+- **Now → 2026-06-18:** Gemini CLI continues serving AI Pro / Ultra / Free tiers in parallel with Antigravity CLI.
+- **2026-06-18:** Gemini CLI sunsets for non-enterprise. Enterprise paid licenses retained.
+- **After sunset:** Antigravity CLI is the sole successor; `.gemini/` paths fade to legacy.
+
+**Primary authoritative sources:**
+- <https://developers.googleblog.com/build-with-google-antigravity-our-new-agentic-development-platform/>
+- <https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/>
+- <https://antigravity.google/>
+- <https://codelabs.developers.google.com/getting-started-with-antigravity-skills>
+- <https://geminicli.com/docs/cli/skills/> (Gemini lineage; transitional)
+- <https://geminicli.com/docs/hooks/reference/> (Gemini lineage; transitional)
+- <https://github.com/google/skills>
+
+---
+
+## 1. File system layout
+
+| Artifact | Project scope (Antigravity) | Project scope (Gemini, legacy) | User scope |
+|---|---|---|---|
+| Skills | `<workspace>/.agent/skills/<name>/SKILL.md` (singular — Antigravity per codelab); `.agents/skills/<name>/SKILL.md` (cross-tool alias, plural) | `.gemini/skills/<name>/SKILL.md` | `~/.gemini/antigravity/skills/` (transitional global) or `~/.gemini/skills/` (legacy) |
+| Slash commands | (under-documented for Antigravity) | `.gemini/commands/<name>.toml` | `~/.gemini/commands/` |
+| Hooks | (under-documented for Antigravity) | `.gemini/settings.json` → `hooks` object | `~/.gemini/settings.json` |
+| MCP servers | (under-documented for Antigravity) | `mcpServers` JSON key inside `.gemini/settings.json` | same |
+| Extensions / plugins | "Antigravity plugins" — `gemini-extension.json` (renamed in transition, layout TBD) | `~/.gemini/extensions/<name>/gemini-extension.json` | same |
+| Memory file | `GEMINI.md` (inherited; configurable via `context.fileName` array) | `GEMINI.md` (workspace + ancestors) | `~/.gemini/GEMINI.md` |
+| System config | TBD | `/etc/gemini-cli/settings.json` | — |
+
+**Discovery precedence within a tier** (Gemini-lineage; assumed to carry over): built-in → extension → user → workspace. `.agents/skills/` beats `.gemini/skills/` (cross-tool path wins).
+
+**Uncertainty (verify before scoring):**
+- `<workspace>/.agent/skills/` (singular, from Antigravity codelab) vs `.agents/skills/` (plural, cross-tool alias from agentskills.io) — both may be true (Antigravity-specific singular path + cross-tool plural alias), or one may be a documentation error. Recommend recognizing both as valid skill paths.
+
+---
+
+## 2. SKILL.md (Tier 1, open spec — `name`, `description` required only)
+
+Antigravity (and Gemini CLI) explicitly adopt the agentskills.io open standard. Required: `name`, `description`. Same as every other tool.
+
+**Antigravity/Gemini-specific extensions** documented to date:
+- `activate_skill` tool invocation (in-agent) to load a skill on demand.
+- Mandatory user-consent prompt before injection (filesystem-access grant).
+- `/skills` slash command (in-agent) lists installed skills.
+- `gemini skills` terminal command (list/install/uninstall) — Gemini-only; Antigravity CLI uses `npx skills add` instead.
+
+**Install verbs:**
+- Cross-tool: `npx skills add github.com/google/skills` (per `github.com/google/skills` repo page).
+- Legacy Cloud Next blog wording: `npx skills install` (treat as equivalent; `add` is the canonical command).
+- Gemini CLI: `gemini extensions install <github-url|path>`.
+
+---
+
+## 3. `gemini-extension.json` (extension manifest, becoming "Antigravity plugin")
+
+```json
+{
+  "name": "my-extension",
+  "version": "1.0.0",
+  "mcpServers": { /* MCP server registrations */ },
+  "contextFileName": "AGENTS.md",
+  "excludeTools": ["WebFetch"]
+}
+```
+
+Required: `name`, `version`. Notable optional: `mcpServers`, `contextFileName`, `excludeTools`. The rename to "Antigravity plugin" is announced; the manifest schema is documented to "preserve" extension semantics but Google hasn't published the full delta.
+
+---
+
+## 4. `.gemini/commands/<name>.toml` (slash commands — TOML)
+
+```toml
+prompt = """
+Review the diff and check for {{args}}.
+"""
+description = "Custom code review with focus area"
+```
+
+**Required field:** `prompt`.
+**Optional:** `description` (auto-generated from filename if omitted).
+
+**Template syntax** (Gemini-specific):
+- `{{args}}` — raw argument injection.
+- `!{shell command}` — runs shell, args auto-escaped.
+- `@{path}` — file/directory injection. Respects `.gitignore` and `.geminiignore`. Supports PNG/JPEG/PDF/audio/video.
+
+Subdirectory layout becomes a namespace: `.gemini/commands/ns/cmd.toml` → `/ns:cmd`.
+
+**Antigravity CLI status:** unclear whether TOML slash commands carry over. Treat as legacy-only for now; Antigravity-specific command format TBD.
+
+---
+
+## 5. Hook events (Gemini lineage — fundamentally different from Claude/Codex)
+
+Gemini (and inherited Antigravity) decomposes the lifecycle into Agent/Model/Tool layers, not the tool-centric model Claude and Codex use.
+
+| Event | Trigger |
+|---|---|
+| `SessionStart` | Session begin |
+| `BeforeAgent` | Before each agent turn |
+| `BeforeModel` | Before LLM invocation |
+| `BeforeToolSelection` | Before the model decides which tool to call |
+| `BeforeTool` | Before tool execution (after selection) |
+| `AfterTool` | After tool execution |
+| `AfterModel` | After LLM response |
+| `AfterAgent` | After agent turn complete |
+| `SessionEnd` | Session end |
+| `Notification` | On notification |
+| `PreCompress` | Before context compaction (Gemini's name for Claude's `PreCompact`) |
+
+**No 1:1 mapping to Claude Code or Codex events.** Specifically:
+- Gemini's `BeforeModel` vs `BeforeToolSelection` distinction has no Claude/Codex analog — both fall under Claude's `PreToolUse`.
+- Gemini has no equivalent of Claude's `UserPromptSubmit` or `PermissionRequest`.
+
+**I/O contract** (Gemini lineage): JSON on stdin with `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `timestamp`. JSON on stdout: `systemMessage`, `decision` (`"allow"`/`"deny"`), `reason`, `continue`, `suppressOutput`. Exit codes: `0` = ok, `2` = block (stderr = reason), other = warning.
+
+**Antigravity CLI hook event names:** TBD — Google's transition post says "preserves hooks" without enumerating the event set. Treat the Gemini list as the current best guess.
+
+---
+
+## 6. GEMINI.md (memory file — sophisticated hierarchy)
+
+`GEMINI.md` is hierarchical: `~/.gemini/GEMINI.md` → workspace + ancestor `GEMINI.md` files → JIT-discovered `GEMINI.md` on file access. All concatenated per prompt.
+
+**Distinctive features (versus AGENTS.md and CLAUDE.md):**
+- Supports `@file.md` imports (relative + absolute paths).
+- Filename is configurable via `context.fileName` in `settings.json`, which accepts an **array** — e.g., `context.fileName: ["AGENTS.md", "CONTEXT.md", "GEMINI.md"]`. This is the official interop hook for AGENTS.md (Codex's canonical) and CLAUDE.md (Claude Code's canonical).
+
+**Recommended pattern for multi-tool projects:**
+- Set `context.fileName: ["AGENTS.md"]` in `.gemini/settings.json` — makes Gemini/Antigravity read AGENTS.md directly. nlpm decision #5: AGENTS.md is the canonical universal memory file.
+
+---
+
+## 7. MCP integration
+
+Gemini reads MCP servers from `mcpServers` key inside `~/.gemini/settings.json` or `.gemini/settings.json` (NOT a separate `.mcp.json` file). Standard MCP server shape: `command`, `args`, `env`. Also configurable inside `gemini-extension.json` for extension-bundled servers.
+
+Slash commands: `/mcp list`, `/mcp auth`.
+
+**Antigravity CLI MCP layout:** TBD.
+
+---
+
+## 8. Plugin marketplace
+
+**No central JSON marketplace manifest** documented for Gemini CLI today. Discovery is via the Extensions Gallery at <https://geminicli.com/extensions/> (community/partner/Google), GitHub-stars ranked, installed via `gemini extensions install <github-url|path>`.
+
+**Antigravity CLI marketplace** layout: TBD.
+
+**`github.com/google/skills`** is the official Google-published skills registry. Organized under `skills/cloud/...`. Installed via `npx skills add google/skills`. Cross-tool — targets Antigravity, Gemini CLI, Codex CLI, Claude Code, Cursor, and others.
+
+---
+
+## 9. Recent material changes (last 6 months)
+
+| Date | Event |
+|---|---|
+| 2025-11-20 | Original Antigravity public preview |
+| 2026-04 (Cloud Next) | `github.com/google/skills` official registry launched; `npx skills` cross-agent installer |
+| 2026-05 | Extensions Gallery launched (Dynatrace, Elastic, Figma, Harness as partners) |
+| **2026-05-19 (Google I/O)** | **Antigravity 2.0 announced; Antigravity CLI GA; Gemini CLI deprecation announced** |
+| 2026-06-18 (pending) | Gemini CLI stops serving AI Pro/Ultra/Free tiers |
+
+---
+
+## 10. Scope and uncertainty
+
+This skill covers Antigravity CLI and legacy Gemini CLI conventions during the transition window. It does NOT cover:
+- Universal SKILL.md spec → `nlpm:conventions`
+- Penalty tables → `nlpm:scoring`
+- Antigravity desktop IDE or Antigravity SDK (different artifact surfaces)
+
+**Major uncertainties — defer deep audit until resolved:**
+
+1. **Singular `.agent/` vs plural `.agents/`** — codelab uses singular for Antigravity workspace skills; agentskills.io cross-tool alias uses plural. Auditor should recognize both as valid.
+2. **`npx skills` verb** — `add` per repo page, `install` per Cloud Next blog. `add` is canonical.
+3. **Antigravity directory-rename spec** — Google's transition post says "not 1:1 parity" without enumerating gaps. Monitor for an official migration guide.
+4. **Antigravity-specific hook events** — assumed to inherit Gemini's, but the transition post doesn't confirm.
+5. **`github.com/google-antigravity/antigravity-cli`** — research surfaced this org/repo URL but the namespace differs from `google/` proper. Verify before citing as authoritative.
+6. **"Antigravity plugins" manifest schema** — renamed from Gemini "extensions" but full schema delta not published.
+7. **MCP support in Antigravity** — not contradicted in the transition post, but not explicitly confirmed.
+
+PR-B verification trigger: when Google publishes a stable Antigravity directory-layout spec (or when Antigravity overtakes Gemini CLI in real-world repo count), upgrade this skill from advisory to authoritative and add Antigravity-specific penalty rows to `nlpm:scoring`.

--- a/skills/nlpm/conventions-claude/SKILL.md
+++ b/skills/nlpm/conventions-claude/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: conventions-claude
+description: "Use when scoring or writing Claude Code artifacts — covers .claude/ paths, plugin.json schema, command + agent + skill frontmatter (including v2.1.x additions: context:fork, agent:, paths:, skill-scoped hooks:), CLAUDE.md, hook events, hooks.json format, settings.json, LSP, monitors, memory file conventions, and the Claude Code built-in tool catalog."
+version: 0.1.0
+---
+
+# Claude Code Conventions
+
+Tool-specific overlay for Claude Code plugin artifacts. Loaded by the scorer and checker when an artifact is classified as **Tier 2-Claude** (per `agents/scorer.md` step 3). The universal floor lives in `nlpm:conventions`; this overlay adds Claude-Code-specific schemas on top.
+
+**Primary authoritative sources:**
+- <https://code.claude.com/docs/en/claude_code_docs_map.md>
+- <https://code.claude.com/docs/en/skills.md>
+- <https://code.claude.com/docs/en/hooks.md>
+- <https://code.claude.com/docs/en/plugins.md>
+- <https://code.claude.com/docs/en/plugins-reference.md>
+- <https://code.claude.com/docs/en/sub-agents.md>
+- <https://code.claude.com/docs/en/settings.md>
+- <https://code.claude.com/docs/en/memory.md>
+- <https://code.claude.com/docs/en/slash-commands.md>
+
+---
+
+## 1. `.claude-plugin/plugin.json`
+
+The plugin manifest.
+
+**Required fields:**
+- `name` — string, kebab-case, unique identifier
+
+**Optional fields:**
+- `version` — semver string (e.g. `"0.1.0"`). If omitted, commit SHA is used (every commit = new version). For stable releases, set explicit semver.
+- `description` — one-line summary
+- `author` — object: `{ "name": "...", "email": "...", "url": "..." }`
+- `homepage` — URL string
+- `repository` — URL string or object
+- `license` — SPDX identifier
+- `keywords` — string array for discovery
+- `agent` — sets the default agent when the plugin is enabled
+- `category` — marketplace category (e.g. `"developer-tools"`)
+
+**Component path fields (all optional, string or string[]):**
+- `commands` — path(s) to command markdown files
+- `agents` — path(s) to agent markdown files
+- `skills` — path(s) to skill directories
+- `hooks` — path to hooks.json
+- `mcpServers` — path(s) to MCP server config
+- `lspServers` — path(s) to LSP server config (stable in 2026)
+- `outputStyles` — path(s) to output style definitions
+
+**Example:**
+```json
+{
+  "name": "my-plugin",
+  "version": "0.2.1",
+  "description": "Does useful things",
+  "author": { "name": "dev" },
+  "license": "MIT",
+  "keywords": ["tools", "productivity"],
+  "commands": "commands/",
+  "agents": "agents/",
+  "skills": "skills/"
+}
+```
+
+---
+
+## 2. Commands and Skills — merged surfaces (v2.1.x change)
+
+**Critical:** as of Claude Code v2.1.x, commands and skills are the **same architecture**. Both surfaces support the same frontmatter and execution semantics. The recommended canonical path is:
+
+```
+.claude/skills/<name>/SKILL.md     # preferred for new development
+.claude/commands/<name>.md         # still works; equivalent behavior
+```
+
+Existing `.claude/commands/` files continue to function. New code should prefer the skill layout because it allows companion files (`scripts/`, `references/`, `examples/`) in the same directory.
+
+**Authoritative reference:** <https://code.claude.com/docs/en/slash-commands>
+
+### 2.1 Frontmatter (shared between commands and skills)
+
+**Required:**
+- `description` — string; explains what it does and when to invoke. Combined with `when_to_use:` if present.
+
+**Optional (universal):**
+- `name` — string; per official docs, **explicitly optional**. When omitted, filename or enclosing directory is used. Pre-v0.7.15 nlpm incorrectly flagged missing `name:` as a bug; corrected after Jeffallan/claude-skills#184 maintainer feedback.
+- `argument-hint` — string; placeholder shown in UI (e.g., `"[path]"`)
+- `arguments` — space-separated or YAML list of named arguments for `$name` substitution (e.g., `"issue branch"`)
+- `allowed-tools` — string array OR space-separated string; pre-approved tools (no per-use prompt). Format: `"Read Grep Bash(git *)"` or `["Read", "Grep"]`.
+- `model` — `haiku` / `sonnet` / `opus`; overrides session model for one turn.
+- `effort` — `low` / `medium` / `high` / `xhigh` / `max`; overrides session effort.
+- `user-invocable` — boolean; `false` hides from menu (only Claude invokes).
+- `disable-model-invocation` — boolean; `true` means only the user invokes (manual `/skill-name` only).
+
+**Optional (v2.1.x additions — NEW since pre-2026 conventions):**
+- `when_to_use` — string; additional trigger hints (appends to description)
+- `context` — `"fork"` runs in a forked subagent (isolates from main history)
+- `agent` — which subagent type (built-in: `Explore`, `Plan`, `general-purpose`)
+- `hooks` — `{...}` skill-scoped hooks (same shape as settings.json hooks)
+- `paths` — glob patterns; auto-load only for matching files (e.g., `"src/**/*.ts,lib/**/*.ts"`)
+- `shell` — `bash` (default) or `powershell` for `!`cmd`` blocks
+
+### 2.2 Body conventions
+
+- Write imperative instructions directed at Claude (not the user)
+- Use numbered steps for multi-phase workflows
+- Reference shared partials by relative path: `commands/shared/name.md`
+- Define expected output format explicitly in the body
+
+### 2.3 Dynamic context injection
+
+- `` !`git diff HEAD` `` — runs command before Claude sees the skill; replaces line with output.
+- ` ```! ` fenced blocks — multi-line commands.
+- Disabled if `"disableSkillShellExecution": true` in settings.
+
+---
+
+## 3. Shared Partials
+
+Reusable command fragments located in `commands/shared/`.
+
+**Rules:**
+- MUST include `user-invocable: false` in frontmatter — prevents appearing as top-level commands
+- MUST have a `description` stating their purpose as a partial
+- Referenced by full relative path from the consuming command file
+- Can contain any mix of instructions, templates, or decision logic
+
+---
+
+## 4. Agent Frontmatter
+
+Agents live in `.claude/agents/<name>.md`.
+
+**Documented fields:**
+- `name` — string; identifier for invocation
+- `description` — string; critical for reliable triggering — should contain 3+ specific phrases describing when to use this agent
+- `system-prompt` — string (block scalar); custom system instructions
+
+**Convention fields (strongly recommended):**
+- `model` — `haiku` / `sonnet` / `opus`
+- `effort` — `low` / `medium` / `high` / `xhigh` / `max`
+- `color` — one of `cyan`, `blue`, `magenta`, `yellow`, `green`, `red`; visual label
+- `tools` — tools the agent body uses; two valid formats:
+  - JSON array: `tools: ["Read", "Glob"]`
+  - Comma-separated string: `tools: Read, Glob, Grep`
+- `tool-restrictions` — alternative to `tools:`; `{ allow: [...], deny: [...] }`
+- `skills` — preload skill content into this agent's context at startup. Two valid formats:
+  - JSON array: `skills: ["nlpm:conventions"]`
+  - YAML list: `skills:\n  - nlpm:conventions`
+
+**Best practice: include `<example>` blocks in description.** Two or more `<example>` blocks with diverse scenarios is the minimum for reliable triggering.
+
+---
+
+## 5. Skills — Claude Code path conventions
+
+Universal SKILL.md spec lives in `nlpm:conventions` (open spec at agentskills.io). Claude Code uses these path conventions:
+
+- Single plugin skill: `skills/<name>/SKILL.md`
+- Multi-skill plugin: `skills/<plugin>/<name>/SKILL.md`
+- Project-scoped: `.claude/skills/<name>/SKILL.md`
+- User-scoped: `~/.claude/skills/<name>/SKILL.md`
+
+**Skill discovery paths now support parent-directory and monorepo nested scanning** (v2.1.x). Skills from `./parent/.claude/skills/` and `./packages/frontend/.claude/skills/` auto-load. Skills from `--add-dir` paths also load from `.claude/skills/` within added directories.
+
+**Supporting files:** Same directory as `SKILL.md` — `scripts/`, `references/`, `examples/`, etc. Reference them from `SKILL.md` so Claude knows when to load them.
+
+**Skill preloading in agents (v2.1.x):** Declare `skills: [name1, name2]` in agent frontmatter to inject full skill content at startup (vs. Claude auto-loading on demand).
+
+---
+
+## 6. Rules
+
+Rules live in `.claude/rules/<name>.md`.
+
+**Frontmatter:**
+- `description` — string (required)
+- `paths` — string array (optional); glob patterns scoping which files this rule applies to
+
+**Body format:**
+- Lead with a **bold imperative**: `**Always do X.**` or `**Use Y instead of Z.**`
+- Follow immediately with rationale
+- Be specific and testable
+- State what to DO, not only what to avoid (Pink Elephant effect)
+
+**Budget:** Under 500 lines total per rules file.
+
+**Naming convention for ordered sets:** `NN-kebab-name.md` (e.g. `01-formatting.md`).
+
+---
+
+## 7. Hook Events (Claude Code)
+
+Hook events are **case-sensitive**. Using wrong case silently ignores the hook.
+
+**Confirmed against 2026-05 docs refresh:**
+
+| Event | Trigger | Context fields |
+|---|---|---|
+| `SessionStart` | Session begin | `source` (startup/resume/clear/compact), `model` |
+| `SessionEnd` | Session end | (trigger only) |
+| `UserPromptSubmit` | User submits a prompt | `prompt` text |
+| `PreToolUse` | Before any tool call | `tool_name`, `tool_input` |
+| `PostToolUse` | After tool call | `tool_name`, `tool_input`, `tool_output` |
+| `PermissionRequest` | When Claude requests permission | `tool_name`, `tool_input`, `permission_mode` |
+| `Stop` | Once per turn | `reason` (can set `decision: block` to prevent stopping) |
+| `StopFailure` | Once per turn — Claude failed to complete | `reason` |
+| `FileChanged` | Per file change | `filename`, `watcher_path` |
+
+**Present in older conventions docs, status uncertain in current docs — verify before flagging:**
+`SubagentStop`, `PreCompact`, `Notification`, `PostToolUseFailure`, `InstructionsLoaded`, `TaskCompleted`. nlpm should NOT penalize these as "unknown" until verified against current `code.claude.com/docs/en/hooks.md`.
+
+**Hook types** (canonical, all lowercase in JSON):
+- `command` — shell script (stdin/stdout)
+- `http` — HTTP POST endpoint
+- `mcp_tool` — MCP server tool invocation
+- `prompt` — LLM evaluation
+- `agent` — subagent verification
+
+**Matcher patterns:** string (exact), pipe-separated list (`Bash|Edit`), or regex (non-alphanumeric chars).
+
+**MCP tool naming:** `mcp__<server>__<tool>` (e.g., `mcp__memory__write.*`). Hook matchers use this format.
+
+**Exit codes (command hooks):**
+- `0` — success (stdout as JSON or context)
+- `2` — blocking error (action denied, stderr shown)
+- `1, 3+` — non-blocking (logged in debug only)
+
+---
+
+## 8. `hooks.json` Format
+
+Located at `.claude/hooks.json` or `<plugin>/hooks/hooks.json`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-write-check.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "You are now in strict TDD mode."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Structure rules:**
+- Top-level key: `"hooks"`
+- Second-level keys: event names (case-sensitive)
+- Each event maps to an array of matcher objects: `{ "matcher": "<regex>", "hooks": [...] }`
+- Each hook object: `{ "type": "command"|"http"|"mcp_tool"|"prompt"|"agent", "<type-field>": "..." }`
+- Field name matches the type: `"command"` for type `command`, `"prompt"` for type `prompt`, etc.
+
+---
+
+## 9. `.mcp.json`
+
+Claude Code reads MCP server registrations from a **standalone JSON file** at the repo root (NOT embedded in `settings.json` like Gemini, NOT inside `config.toml` like Codex).
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./server.js"]
+    }
+  }
+}
+```
+
+Plugin scope: `<plugin>/.claude-plugin/.mcp.json` or `<plugin>/.mcp.json` (path per `plugin.json`).
+
+---
+
+## 10. CLAUDE.md (memory file)
+
+Project-scoped: `CLAUDE.md` at repo root, plus optional `.claude/memory/*.md`. User-scoped: `~/.claude/CLAUDE.md`.
+
+**Recommended pattern for multi-tool projects** (per `analysis/multi-tool-design-2026-05.md` decision #5): use a one-line `CLAUDE.md` that imports `AGENTS.md`:
+
+```markdown
+@AGENTS.md
+```
+
+This makes AGENTS.md the canonical universal memory file. AGENTS.md is what Codex reads natively; Gemini/Antigravity can be configured to read it via `context.fileName` array. This is how nlpm itself works.
+
+**Body conventions** when content lives in CLAUDE.md directly:
+- Build/run instructions
+- Test commands
+- Architecture overview (what lives where)
+- Prerequisites section
+- Valid `@`-imports must reference existing files
+
+---
+
+## 11. `.claude/settings.json` and `.claude/settings.local.json`
+
+| Field | Purpose |
+|---|---|
+| `permissions` | Permission policy (allow/deny rules, modes) |
+| `hooks` | Hook event registrations (alternative to `hooks/hooks.json` for project-scoped hooks) |
+| `model` | Default model selection |
+| `theme` | UI theme |
+| `disableSkillShellExecution` | If `true`, disables `!`...`` and ` ```! ` dynamic blocks in skills |
+
+**Rule:** `.local.json` is gitignored (per-user); the non-local file is shared. NEVER set `bypassPermissions: true` in the shared file.
+
+---
+
+## 12. LSP Servers (`.lsp.json`)
+
+**Stable in 2026 (was experimental in 2025).** Plugin-level LSP server registrations.
+
+Schema details out of scope for this version; PR-B trigger: when scoring shows LSP-related findings appearing in audits, add a dedicated subsection here. Until then, scorer recognizes presence of `.lsp.json` and validates JSON-parse only.
+
+---
+
+## 13. Monitors (`monitors/monitors.json`)
+
+**Stable in 2026 (was experimental in 2025).** Plugin-level background watchers (logs, files, status).
+
+Schema details out of scope for this version (same staging as LSP). Scorer validates JSON-parse only.
+
+---
+
+## 14. Reference Syntax
+
+**Commands referencing shared partials:**
+```
+<!-- Include: commands/shared/discover.md -->
+```
+Or by instruction: "Follow the steps in commands/shared/discover.md"
+
+**Agents referencing skills in frontmatter:**
+```yaml
+skills: ["nlpm:conventions", "nlpm:conventions-claude"]
+```
+
+**Hooks referencing scripts:**
+```json
+"command": "${CLAUDE_PLUGIN_ROOT}/scripts/check.sh"
+```
+
+**Always use `${CLAUDE_PLUGIN_ROOT}` for intra-plugin file references.** Hardcoded absolute paths break portability.
+
+**Cross-plugin skill references** use the same `plugin:skill` format. The plugin must be installed for the reference to resolve.
+
+---
+
+## 15. Memory File Conventions (`~/.claude/projects/<slug>/memory/`)
+
+Claude Code writes per-project persistent memory at `~/.claude/projects/<project-slug>/memory/`.
+
+**Index file:** `MEMORY.md` (no frontmatter; one-line-per-entry index).
+
+**Individual memory files** MUST include YAML frontmatter:
+
+```yaml
+---
+name: "short identifier"
+description: "one-line summary"
+type: user | feedback | project | reference
+---
+```
+
+**`type` values:**
+
+| Value | Meaning |
+|---|---|
+| `user` | Preferences, habits, or facts about the user |
+| `feedback` | Corrections or lessons from past sessions |
+| `project` | Project-specific facts, decisions, or context |
+| `reference` | External reference material copied into memory |
+
+**Rules:**
+- Every memory file must appear in `MEMORY.md` (orphans are flagged).
+- `MEMORY.md` itself is the index; not scored as a memory file.
+- Memory files should not reference removed files or functions.
+
+---
+
+## 16. Claude Code Tool Catalog
+
+Tool names valid in `tools:` and `allowed-tools:`. Do NOT flag any as "undocumented" or "unknown".
+
+**Built-in tools:**
+- File I/O: `Read`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit`
+- Discovery: `Glob`, `Grep`
+- Execution: `Bash`, `BashOutput`, `KillBash`
+- Agent: `Task`
+- Web: `WebFetch`, `WebSearch`
+- User interaction: `AskUserQuestion`
+- Planning: `TodoWrite`
+- Commands: `SlashCommand`
+- Scheduling: `ScheduleWakeup`
+- Skill invocation: `Skill`
+- Tool discovery: `ToolSearch`
+
+**MCP tools:** `mcp__<server-name>__<tool-name>` (e.g., `mcp__mermaider__validate_syntax`).
+
+Tool names are case-sensitive. Any string matching the patterns above is a valid tool reference regardless of whether this document pre-dates the tool's introduction.
+
+---
+
+## 17. Plugin distribution
+
+**Marketplace manifest:** `.claude-plugin/marketplace.json` at the marketplace repo root. Schema:
+
+```json
+{
+  "name": "marketplace-name",
+  "plugins": [
+    {
+      "name": "plugin-name",
+      "source": {
+        "source": "github",
+        "repo": "owner/repo"
+      },
+      "description": "...",
+      "version": "1.0.0",
+      "author": { "name": "..." },
+      "repository": "https://github.com/owner/repo",
+      "license": "MIT",
+      "category": "developer-tools"
+    }
+  ]
+}
+```
+
+**Plugin from URL (v2.1.x):** `--plugin-url` and `--plugin-dir` flags accept `.zip` archives.
+
+**Namespacing:** Skills are namespaced (`/my-plugin:hello`). Commands and agents use short names. Prevents conflicts between plugins.
+
+---
+
+## 18. Scope and uncertainty
+
+This skill covers Claude Code conventions. It does NOT cover:
+- Universal SKILL.md spec → `nlpm:conventions`
+- Penalty tables → `nlpm:scoring`
+
+**Uncertainties flagged for verification:**
+- `SubagentStop`, `PreCompact`, `Notification`, `PostToolUseFailure`, `InstructionsLoaded`, `TaskCompleted` — present in older nlpm conventions, status in current docs unverified (PR-B refresh did not enumerate them).
+- LSP server schema (`.lsp.json`) — stable but no detailed field list captured.
+- Monitor schema (`monitors/monitors.json`) — same.

--- a/skills/nlpm/conventions-codex/SKILL.md
+++ b/skills/nlpm/conventions-codex/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: conventions-codex
+description: "Use when scoring or writing Codex CLI artifacts — covers .codex/config.toml schema, .codex-plugin/plugin.json, .agents/skills/ layout, Codex hook events, AGENTS.md hierarchy, marketplace.json, and the agents/openai.yaml sidecar."
+version: 0.1.0
+---
+
+# Codex CLI Conventions
+
+Tool-specific overlay for OpenAI Codex CLI artifacts. Loaded by the scorer and checker when an artifact is classified as **Tier 2-Codex** (per `agents/scorer.md` step 3). The universal floor lives in `nlpm:conventions`; this overlay adds Codex-specific schemas on top.
+
+**Primary authoritative sources:**
+- <https://developers.openai.com/codex>
+- <https://developers.openai.com/codex/skills>
+- <https://developers.openai.com/codex/guides/agents-md>
+- <https://developers.openai.com/codex/config-reference>
+- <https://developers.openai.com/codex/hooks>
+- <https://developers.openai.com/codex/plugins>
+- <https://github.com/openai/codex>
+
+---
+
+## 1. File system layout
+
+Codex separates the **cross-tool surface** (`.agents/`) from the **Codex-private surface** (`.codex/`). The Claude Code mental model of "everything under one tool directory" does not transfer.
+
+| Artifact | Project scope | User scope |
+|---|---|---|
+| Skills | `.agents/skills/<name>/SKILL.md` | `~/.agents/skills/` |
+| Plugin manifest | `<plugin-root>/.codex-plugin/plugin.json` | — |
+| Marketplace | `.agents/plugins/marketplace.json` | `~/.agents/plugins/marketplace.json` |
+| AGENTS.md | Git root → CWD (concatenated; closer overrides earlier) | `~/.codex/AGENTS.md`, `~/.codex/AGENTS.override.md` |
+| Config | `.codex/config.toml` (trust-gated) | `~/.codex/config.toml` |
+| Hooks | `.codex/hooks.json` OR inline `[hooks]` in `config.toml` | `~/.codex/hooks.json` |
+| Slash commands (deprecated) | — (not project-shareable) | `~/.codex/prompts/<name>.md` |
+| MCP servers | `[mcp_servers.<id>]` table inside `config.toml` | same |
+| Skill sidecar (Codex-specific) | `<skill>/agents/openai.yaml` next to `SKILL.md` | — |
+
+**Trust gate:** Project hooks load only when `.codex/` is trusted. Trust is enforced via `/hooks` and `allow_managed_hooks_only` in `requirements.toml`.
+
+---
+
+## 2. SKILL.md (Tier 1, open spec — `name`, `description` required only)
+
+Codex reads SKILL.md from `.agents/skills/`, not `.codex/skills/`. The required frontmatter is the agentskills.io baseline — `name` and `description` — same as every other tool.
+
+**Codex-specific extras live in a SIDECAR `agents/openai.yaml`**, not in SKILL.md frontmatter. Treat the sidecar as additive metadata, not a deviation from the open spec.
+
+**Sidecar fields:**
+```yaml
+# <skill>/agents/openai.yaml
+interface:
+  display_name: "My Skill"
+  default_prompt: "Use this skill when..."
+  icon_small: "icon-16.png"
+  brand_color: "#FF6B00"
+policy:
+  allow_implicit_invocation: true
+dependencies:
+  tools:
+    - bash
+    - jq
+```
+
+Duplicate-name skills across scopes are NOT merged — both appear in selectors, repo-level wins for local workflows.
+
+---
+
+## 3. `.codex-plugin/plugin.json` (plugin manifest)
+
+```json
+{
+  "name": "my-codex-plugin",
+  "version": "1.0.0",
+  "description": "Short summary",
+  "skills": ["./skills/foo"],
+  "mcpServers": ["./mcp/bar.toml"],
+  "apps": ["./apps/baz.app.json"],
+  "hooks": ["./hooks.json"],
+  "interface": {
+    "displayName": "My Plugin",
+    "longDescription": "Detailed description for installer UI"
+  }
+}
+```
+
+**Required fields:** `name` (kebab-case), `version` (semver), `description`.
+**Optional component paths** (all relative `./` paths only): `skills`, `mcpServers`, `apps`, `hooks`.
+**Optional UI block:** `interface.{displayName, longDescription, defaultPrompt, …}`.
+
+---
+
+## 4. `.agents/plugins/marketplace.json` (marketplace manifest)
+
+Three marketplace tiers exist in Codex:
+
+- **Official Curated** — OpenAI-managed; self-serve publishing "coming soon" as of May 2026.
+- **Repository** — `<repo-root>/.agents/plugins/marketplace.json` aggregates plugins shipped from that repo.
+- **Personal** — `~/.agents/plugins/marketplace.json`.
+
+Schema:
+
+```json
+{
+  "name": "xiaolai",
+  "interface": {
+    "displayName": "xiaolai Marketplace"
+  },
+  "plugins": [
+    {
+      "name": "nlpm",
+      "source": {
+        "source": "github",
+        "repo": "xiaolai/nlpm"
+      },
+      "policy": {
+        "installation": "auto",
+        "authentication": "none"
+      },
+      "category": "developer-tools",
+      "interface": {
+        "displayName": "nlpm"
+      }
+    }
+  ]
+}
+```
+
+Per-plugin `source` types: `"github"`, `"git"`, `"local"`.
+
+---
+
+## 5. `.codex/config.toml`
+
+TOML — NOT JSON. Top-level sections nlpm cares about:
+
+- `[features]` — feature flags. **Breaking change ~2026-04 (CLI 0.129+):** `[features].codex_hooks` was renamed to `[features].hooks`. Old key emits a deprecation warning. Flag config files that still use `codex_hooks`.
+- `[mcp_servers.<id>]` — MCP server registrations. Fields: `command`, `args`, `cwd`, `url`, `enabled`, `enabled_tools`, `disabled_tools`, `env`, `startup_timeout_sec`.
+- `[hooks.<event>]` — inline hook registrations (alternative to `.codex/hooks.json`).
+- `[agents.<name>]` — subagent definitions (Codex multi-agent feature).
+- `[profiles.*]` — named permission/model profiles.
+- `[permissions.*]` — permission policy.
+
+**No `.mcp.json` at repo root.** Codex does NOT read Claude's `.mcp.json` — MCP servers live inside `config.toml`. A bridge from `.mcp.json` → `.codex/config.toml` is a common port pattern (see `cc-suite:bridge-mcp` skill).
+
+---
+
+## 6. Hook events (Codex CLI)
+
+Codex hooks mostly mirror Claude Code's event names — easier than the Antigravity divergence.
+
+| Event | In Claude? | In Antigravity? | Notes |
+|---|---|---|---|
+| `SessionStart` | yes | yes | — |
+| `UserPromptSubmit` | yes | — | — |
+| `PreToolUse` | yes | — (different model) | — |
+| `PostToolUse` | yes | — | — |
+| `PermissionRequest` | yes | — | — |
+| `PreCompact` | yes | — (uses `PreCompress`) | — |
+| `PostCompact` | — | — | **Codex-only** (Claude has no PostCompact) |
+| `SubagentStart` | — | — | **Codex-only** (added 2026-05-21 in 0.133.0) |
+| `SubagentStop` | yes | — | — |
+| `Stop` | yes | — | — |
+
+**Absent in Codex (but present in Claude):** `Notification`, `SessionEnd`, `FileChanged`, `StopFailure`.
+
+**Hook I/O contract:** Same JSON-on-stdin / JSON-on-stdout shape as Claude. Stdin: `session_id`, `cwd`, `hook_event_name`, `tool_name`, `tool_input`, etc. Stdout: `continue`, `systemMessage`, `stopReason`, `permissionDecision`. Exit codes: `0` = ok, `2` = block (stderr = reason), other = warning.
+
+---
+
+## 7. AGENTS.md (Codex's canonical memory file)
+
+Codex reads `AGENTS.md` before every turn. Hierarchical: global `AGENTS.override.md` → global `AGENTS.md` → project AGENTS.md files (root-down, closer overrides earlier) → CWD AGENTS.md.
+
+**Default cap:** 32 KiB per file (`project_doc_max_bytes` in config.toml).
+**Fallback filenames:** Configurable via `project_doc_fallback_filenames` — this is the official hook for AGENTS.md / CLAUDE.md / GEMINI.md interop (set the array to include all three to make Codex read whichever exists).
+
+**Body conventions** (not enforced, but common):
+- `## Working agreements` — high-level decisions
+- `## Repository expectations` — invariants
+- `@file.md` imports are NOT supported (unlike Gemini's GEMINI.md hierarchy) — use file concatenation instead.
+
+The nlpm pattern of `CLAUDE.md` → one line `@AGENTS.md` does NOT work for Codex (no @-import). Codex authors should put content directly in AGENTS.md and configure Claude Code's CLAUDE.md to import it instead.
+
+---
+
+## 8. Slash commands (deprecated)
+
+Codex's old slash-command format (`~/.codex/prompts/<name>.md`) is **deprecated in favor of skills**. nlpm should NOT penalize their presence (legacy users still maintain them) but should emit an advisory recommending migration to `.agents/skills/`.
+
+Placeholders if scoring legacy prompts: `$1..$9`, `$ARGUMENTS`, `$FILE`, `$TICKET_ID`, `$$`.
+
+---
+
+## 9. Recent breaking / material changes (last 6 months)
+
+| Date | Version | Change |
+|---|---|---|
+| 2026-03-26 | — | Plugin marketplace **launched**. New artifact class. |
+| ~2026-04 | 0.129.0 | `[features].codex_hooks` renamed to `[features].hooks` (deprecation warning) |
+| 2026-05-18 | 0.131.0 | Plugin hooks enabled by default; legacy shell tools + built-in MCPs removed; `codex doctor` added |
+| 2026-05-21 | 0.133.0 | Goals enabled by default; `SubagentStart` event observable by hooks |
+
+Repos relying on the removed built-in MCPs will silently regress under 0.131+. nlpm should flag MCP configs that name MCPs no longer shipped natively.
+
+---
+
+## 10. Scope and uncertainty
+
+This skill covers Codex CLI conventions. It does NOT cover:
+- Universal SKILL.md spec → `nlpm:conventions`
+- Penalty tables → `nlpm:scoring`
+- Cross-component validation → invoked by `agents/checker.md`
+
+**Uncertainties flagged (verify before scoring with confidence):**
+- `child_agents_md` feature flag semantics — referenced in `agents_md.md` but not fully documented at developers.openai.com.
+- `.app.json` schema for plugin `apps` field — referenced but no canonical doc found.
+- Exact merge boundary between `~/.codex/AGENTS.md` and project AGENTS.md — docs say "global first, closer overrides" but the layer split is implied, not stated.
+- OpenAI's contributor licensing policy for PRs into `openai/codex`-ecosystem repos — research needed before the auditor pipeline (PR-C) scales Codex contributions.

--- a/skills/nlpm/conventions/SKILL.md
+++ b/skills/nlpm/conventions/SKILL.md
@@ -1,347 +1,108 @@
 ---
 name: conventions
-description: "Use when writing, reviewing, or validating Claude Code plugin artifacts — check frontmatter schemas, hook event names, naming conventions, prompt structure, or reference syntax. Loaded by the NLPM scorer and checker agents for schema validation."
-version: 0.1.0
+description: "Universal NL programming conventions — SKILL.md open spec (agentskills.io), AGENTS.md as canonical universal memory file, vague-quantifier list, prompt engineering layers, naming conventions, the override system. Tool-specific schemas live in nlpm:conventions-claude / nlpm:conventions-codex / nlpm:conventions-antigravity."
+version: 0.2.0
 ---
 
-# Claude Code Plugin Conventions
+# Universal NL Programming Conventions
 
-Canonical reference for all NL programming artifact schemas, frontmatter fields, hook events, and naming conventions. Use this skill when linting, writing, or reviewing any Claude Code plugin component.
+The cross-tool floor for all artifact schemas. Use this skill when scoring or writing any NL programming artifact regardless of which tool (Claude Code / Codex CLI / Antigravity) it targets.
 
----
+**Tool-specific overlays** load on top of this universal floor:
+- `nlpm:conventions-claude` — Claude Code artifacts (`.claude/`, `plugin.json`, etc.)
+- `nlpm:conventions-codex` — Codex CLI artifacts (`.codex/`, `.agents/`, `AGENTS.md`)
+- `nlpm:conventions-antigravity` — Antigravity (and legacy Gemini CLI) artifacts (`.gemini/`, `.agent/`)
 
-## 1. plugin.json
+The scorer loads the matching overlay per tier classification — see `agents/scorer.md` step 3.
 
-The plugin manifest. Located at `.claude-plugin/plugin.json`.
-
-**Required fields:**
-- `name` — string, kebab-case, unique identifier
-
-**Optional fields:**
-- `version` — semver string (e.g. `"0.1.0"`)
-- `description` — one-line summary of what the plugin does
-- `author` — object: `{ "name": "...", "email": "...", "url": "..." }`
-- `homepage` — URL string
-- `repository` — URL string or object
-- `license` — SPDX identifier (e.g. `"MIT"`)
-- `keywords` — string array for discovery
-
-**Component path fields (all optional, string or string[]):**
-- `commands` — path(s) to command markdown files
-- `agents` — path(s) to agent markdown files
-- `skills` — path(s) to skill directories
-- `hooks` — path to hooks.json
-- `mcpServers` — path(s) to MCP server config
-- `lspServers` — path(s) to LSP server config
-- `outputStyles` — path(s) to output style definitions
-
-**Example:**
-```json
-{
-  "name": "my-plugin",
-  "version": "0.2.1",
-  "description": "Does useful things",
-  "author": { "name": "dev" },
-  "license": "MIT",
-  "keywords": ["tools", "productivity"],
-  "commands": "commands/",
-  "agents": "agents/",
-  "skills": "skills/"
-}
-```
+**Design rationale:** `analysis/multi-tool-design-2026-05.md`.
 
 ---
 
-## 2. Command Frontmatter
+## 1. SKILL.md — Cross-Tool Open Standard
 
-Commands live in `commands/*.md`. Frontmatter is YAML between `---` delimiters.
+SKILL.md is the **Agent Skills open spec**, stewarded by the Agentic AI Foundation under the Linux Foundation. Anthropic published the spec on 2025-12-18; OpenAI, Microsoft, Google adopted within 48 hours. By 2026-03, 32+ tools read the same SKILL.md format (Claude Code, Codex, Gemini CLI / Antigravity, Cursor, Kiro, Continue, etc.).
 
-**Authoritative reference:** <https://code.claude.com/docs/en/slash-commands>
-
-**Required fields:**
-- `description` — string; explains what the command does and when to invoke it
-
-**Optional fields:**
-- `name` — string; per the official docs, **explicitly optional**. When
-  omitted, Claude Code falls back to the filename (or enclosing
-  directory for SKILL.md-style layouts). Pre-v0.7.15 NLPM incorrectly
-  flagged missing `name:` as a bug; the rule was corrected after
-  Jeffallan/claude-skills#184 maintainer feedback citing the same docs.
-- `argument-hint` — string; shown in UI as placeholder (e.g. `"[path]"`, `"<file>"`)
-- `allowed-tools` — string array; tools Claude may call while executing this command
-- `model` — one of `haiku`, `sonnet`, `opus`; selects model tier
-- `user-invocable` — boolean; set `false` for shared partials that should not appear in menus
-
-**Body convention:**
-- Write imperative instructions directed at Claude (not the user)
-- Use numbered steps for multi-phase workflows
-- Reference shared partials by relative path: `commands/shared/name.md`
-- Define the expected output format explicitly in the body
-
-**Example:**
-```yaml
----
-description: "Lint all NL artifacts in the current project and report quality scores"
-argument-hint: "[path]"
-allowed-tools: ["Read", "Glob"]
-model: sonnet
----
-```
-
----
-
-## 3. Shared Partials
-
-Reusable command fragments. Located in `commands/shared/`.
-
-**Rules:**
-- MUST include `user-invocable: false` in frontmatter — prevents them appearing as top-level commands
-- MUST have a clear `description` stating their purpose as a partial
-- Referenced by full relative path from the consuming command file
-- Can contain any mix of instructions, templates, or decision logic
-
-**Example frontmatter:**
-```yaml
----
-description: "Shared: discover NL artifact files in a directory tree"
-user-invocable: false
-allowed-tools: ["Glob"]
----
-```
-
----
-
-## 4. Agent Frontmatter
-
-Agents live in `agents/*.md`. They are specialized Claude instances invoked by commands or other agents.
-
-**Documented fields:**
-- `name` — string; identifier used when referencing or invoking this agent
-- `description` — string; critical for reliable triggering — should contain 3+ specific phrases describing when to use this agent
-
-**Convention fields (not enforced by schema but strongly recommended):**
-- `model` — `haiku` / `sonnet` / `opus`; declare explicitly
-- `color` — one of `cyan`, `blue`, `magenta`, `yellow`, `green`, `red`; visual label in UI
-- `tools` — tools the agent body actually needs; two valid formats (both accepted by Claude Code):
-  - JSON array: `tools: ["Read", "Glob"]`
-  - Comma-separated string: `tools: Read, Glob, Grep`
-- `skills` — skill references; two valid formats:
-  - JSON array: `skills: ["nlpm:conventions"]`
-  - YAML list: `skills:\n  - nlpm:conventions`
-
-**Best practice: include `<example>` blocks in description:**
-```markdown
----
-description: |
-  Scans a directory for Claude Code artifact files. Use this agent when
-  you need to discover commands, agents, skills, rules, or hooks. Also
-  triggers on "inventory NL files" or "find plugin components".
-
-  <example>
-  Context: User asks to audit a plugin repo
-  user: find all the agent files in this plugin
-  assistant: I'll scan the directory structure for agent markdown files...
-  </example>
-
-  <example>
-  Context: Command invokes scanner as sub-agent
-  user: /scan
-  assistant: Invoking scanner agent to discover NL artifacts...
-  </example>
-model: haiku
-color: cyan
-tools: ["Glob", "Read"]
-skills: ["nlpm:conventions"]
----
-```
-
-Two or more `<example>` blocks with diverse scenarios is the minimum for reliable triggering.
-
----
-
-## 5. Skill Structure
-
-SKILL.md is a **cross-tool open standard** (Agent Skills spec, stewarded
-by the Agentic AI Foundation under the Linux Foundation). Anthropic
-published the spec on 2025-12-18; OpenAI/Microsoft/Google adopted within
-48 hours. By March 2026, 32 tools (Claude Code, Codex, Gemini CLI,
-Cursor, Kiro, Continue, etc.) read the same SKILL.md format.
-
-**Authoritative reference:** https://agentskills.io/specification
+**Authoritative reference:** <https://agentskills.io/specification>
 
 **Required frontmatter (per the open spec):**
-- `name` — string; 1-64 chars, lowercase + hyphens only, MUST match
-  parent directory name. No leading/trailing/consecutive hyphens.
-- `description` — string; 1-1024 chars; should describe what the skill
-  does AND when to use it.
+- `name` — string; 1-64 chars, lowercase + hyphens only, **MUST match parent directory name** (no leading/trailing/consecutive hyphens).
+- `description` — string; 1-1024 chars; should describe what the skill does AND when to use it.
 
 **Optional frontmatter (per the open spec):**
-- `license` — license name or reference to a bundled file
-- `compatibility` — environment requirements (max 500 chars; e.g.,
-  "Designed for Claude Code", "Requires Python 3.14+ and uv")
-- `metadata` — arbitrary key-value mapping (`author`, `version`, etc.
-  go here, NOT as top-level fields)
-- `allowed-tools` — space-separated tool list (experimental; e.g.,
-  `Bash(git:*) Read`)
+- `license` — license name or reference to a bundled file.
+- `compatibility` — environment requirements, max 500 chars (e.g., "Designed for Claude Code", "Requires Python 3.14+ and uv").
+- `metadata` — arbitrary key-value mapping (`author`, `version`, etc. go here, NOT as top-level fields).
+- `allowed-tools` — space-separated tool list (experimental in spec; tool-specific in practice — e.g., `Bash(git:*) Read`).
 
-**Path conventions (Claude Code):**
-- Single plugin skill: `skills/<name>/SKILL.md`
-- Multi-skill plugin: `skills/<plugin>/<name>/SKILL.md`
-- Project-scoped: `.claude/skills/<name>/SKILL.md`
+**Tool-specific extensions to SKILL.md frontmatter** live in the per-tool overlay skills. The scorer applies the universal spec rules to ALL SKILL.md files. Tool-specific overlay rules apply ONLY to files at the matching tool's canonical paths.
 
-**Path conventions (other tools — all are valid skill paths per the open
-spec):**
-- Codex: `.codex/skills/<name>/SKILL.md` (older) or `.agents/skills/<name>/SKILL.md` (canonical)
-- Continue: `.continue/skills/<name>/SKILL.md`
-- Kiro: `.kiro/skills/<name>/SKILL.md`
-- Gemini CLI: `.gemini/skills/<name>/SKILL.md`
+**Skill paths (canonical, per tool):**
 
-NLPM scoring applies the **universal spec rules** to all SKILL.md files
-regardless of path. Claude-Code-specific extensions (e.g., the `model:`
-field on agents, `## Output` section preferences) apply ONLY to files at
-Claude-canonical paths.
+| Tool | Path |
+|---|---|
+| Open-spec (cross-tool) | `.agents/skills/<name>/SKILL.md` |
+| Claude Code | `.claude/skills/<name>/SKILL.md` |
+| Codex CLI | `.agents/skills/<name>/SKILL.md` |
+| Antigravity | `<workspace>/.agent/skills/<name>/SKILL.md` (singular) AND `.agents/skills/<name>/SKILL.md` (cross-tool alias) |
+| Gemini CLI (legacy) | `.gemini/skills/<name>/SKILL.md` |
+| Continue, Cursor, Kiro | `.<tool>/skills/<name>/SKILL.md` |
 
 **Body rules (recommendations, not spec requirements):**
-- Keep under 500 lines — exceeding creates context bloat (spec recommends
-  under 5000 tokens for the body, with overflow in `references/`)
-- Reference material — imperatives belong in commands/agents
-- Include a scope note: what this skill covers and what it does NOT cover
-- Cross-reference related skills with their `plugin:skill` identifiers
+- Keep under 500 lines — exceeding creates context bloat (spec recommends under 5000 tokens for the body, with overflow in `references/`).
+- Reference material — imperatives belong in commands/agents.
+- Include a scope note: what this skill covers and what it does NOT cover.
+- Cross-reference related skills with their `plugin:skill` identifiers.
 
-The spec explicitly says "no format restrictions" on the body — do NOT
-penalize SKILL.md files for missing `## Output` or other section
-conventions. Those are Claude-Code-style preferences, not spec violations.
+The spec explicitly says "no format restrictions" on the body — do NOT penalize SKILL.md files for missing `## Output` or other section conventions. Those are tool-specific style preferences, not spec violations.
 
 **Supporting directories (per the spec):**
 - `scripts/` — executable code (Python, Bash, JavaScript)
-- `references/` — additional docs loaded on demand (REFERENCE.md,
-  FORMS.md, domain-specific files)
+- `references/` — additional docs loaded on demand
 - `assets/` — templates, images, data files
 
 **Progressive disclosure:**
-1. Metadata (~100 tokens): name + description loaded at startup for ALL skills
-2. Instructions (<5000 tokens): full SKILL.md body loaded when activated
-3. Resources: scripts/references/assets loaded only when needed
+1. Metadata (~100 tokens): name + description loaded at startup for ALL skills.
+2. Instructions (<5000 tokens): full SKILL.md body loaded when activated.
+3. Resources: scripts/references/assets loaded only when needed.
 
 ---
 
-## 6. Rules
+## 2. AGENTS.md — Canonical Universal Memory File
 
-Rules live in `.claude/rules/<name>.md`.
+Per nlpm decision (`analysis/multi-tool-design-2026-05.md` §5), AGENTS.md is the canonical universal memory file across all tools nlpm supports.
 
-**Frontmatter:**
-- `description` — string (required); summary shown in rule lists
-- `paths` — string array (optional); glob patterns scoping which files this rule applies to
+**Tool-native support:**
+- **Codex CLI:** reads AGENTS.md natively. Hierarchical (root→cwd; closer overrides earlier). 32 KiB cap. `~/.codex/AGENTS.override.md` for personal overlays.
+- **Antigravity (and Gemini CLI):** reads `GEMINI.md` natively, but `context.fileName` setting accepts an array — set to `["AGENTS.md", "GEMINI.md"]` to make it read AGENTS.md.
+- **Claude Code:** reads `CLAUDE.md` natively, supports `@file.md` import syntax. The canonical pattern is a one-line `CLAUDE.md` containing `@AGENTS.md`.
 
-**Body format:**
-- Lead with a **bold imperative**: `**Always do X.**` or `**Use Y instead of Z.**`
-- Follow immediately with rationale: "Because W, using X ensures..."
-- Be specific and testable — vague rules cannot be linted or enforced
-- State what to DO, not only what to avoid (Pink Elephant effect: prohibitions without alternatives are ignored)
+**Recommended pattern for multi-tool projects:**
 
-**Budget:** Under 500 lines total per rules file.
-
-**Naming convention for ordered sets:** `NN-kebab-name.md` (e.g. `01-formatting.md`, `02-naming.md`)
-
-**Example:**
-```markdown
----
-description: "Always use kebab-case for file and plugin names"
-paths: ["**/*.json", "**/*.md"]
----
-
-**Use kebab-case for all file and plugin names.**
-
-Because Claude Code resolves plugin references by exact string match, inconsistent casing
-causes lookup failures. `my-plugin` and `MyPlugin` are treated as different identifiers.
-
-Correct: `my-plugin`, `tdd-guardian`, `echo-sleuth`
-Incorrect: `myPlugin`, `MyPlugin`, `my_plugin`
+```
+project-root/
+├── AGENTS.md           # canonical content — all instructions live here
+├── CLAUDE.md           # one line: @AGENTS.md
+├── GEMINI.md           # one line: @AGENTS.md  (only if Gemini-native @-import works)
+└── .gemini/settings.json  # set context.fileName: ["AGENTS.md"]
 ```
 
----
+This is exactly how nlpm itself is structured (`CLAUDE.md` → `@AGENTS.md`).
 
-## 7. Hook Events
+**Body conventions** (universal):
+- Open with a one-line project description.
+- `## Architecture` or `## Project Structure` — what lives where.
+- `## Build` / `## Run` / `## Test` — verifiable commands.
+- `## Prerequisites` — required tools / versions / setup.
+- `## Conventions` — naming, style, patterns.
 
-Hook events are **case-sensitive**. Using wrong case silently ignores the hook.
-
-**Available events:**
-| Event | Trigger |
-|-------|---------|
-| `PreToolUse` | Before any tool call |
-| `PostToolUse` | After successful tool call |
-| `PostToolUseFailure` | After failed tool call |
-| `PermissionRequest` | When Claude requests permission |
-| `UserPromptSubmit` | When user submits a prompt |
-| `Stop` | When main agent stops |
-| `SubagentStop` | When sub-agent stops |
-| `SessionStart` | Session initialization |
-| `SessionEnd` | Session teardown |
-| `PreCompact` | Before context compaction |
-| `Notification` | On notification events |
-| `InstructionsLoaded` | After instructions load |
-| `TaskCompleted` | After Claude completes a task |
-
-**Hook types:** `command`, `prompt`, `agent`
-
-**Matcher:** Regex pattern matched against the tool name (for tool hooks). Empty string matches all.
-
-**Permission decision output** (for `PermissionRequest` hooks):
-```json
-{
-  "hookSpecificOutput": {
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "This tool call is safe because..."
-  }
-}
-```
-`permissionDecision` values: `"allow"` or `"deny"`
+**Tool-specific memory-file extensions** (e.g., Claude Code's `@`-import syntax, Gemini's `@{path}` injection, Codex's `project_doc_fallback_filenames`) live in the per-tool overlays.
 
 ---
 
-## 8. hooks.json Format
+## 3. General Prompt Engineering
 
-Located at `.claude/hooks.json` or path specified in `plugin.json`.
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-write-check.sh"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "You are now in strict TDD mode. No production code without a failing test."
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-**Structure rules:**
-- Top-level key: `"hooks"`
-- Second-level keys: event names (case-sensitive)
-- Each event maps to an array of matcher objects
-- Each matcher object: `{ "matcher": "<regex>", "hooks": [...] }`
-- Each hook object: `{ "type": "command"|"prompt"|"agent", "<type-field>": "..." }` where the field name matches the type: `"command"` for type `command`, `"prompt"` for type `prompt`, `"agent"` for type `agent`
-
----
-
-## 9. General Prompt Engineering
+Universal patterns applicable to any NL artifact (commands, agents, skills, prompts) regardless of tool.
 
 **Layer order** (imperative for complex prompts):
 1. Role/persona — "You are a strict code reviewer..."
@@ -358,81 +119,49 @@ Located at `.claude/hooks.json` or path specified in `plugin.json`.
 
 ---
 
-## 10. Naming Conventions
+## 4. Vague Quantifiers (R01)
+
+The R01 rule penalizes unbounded quantifiers without measurable criteria. The penalty applies regardless of which tool the artifact targets.
+
+**Penalized terms:** `appropriate`, `relevant`, `as needed`, `sufficient`, `adequate`, `reasonable`, `properly`, `correctly`, `some`, `several`, `various`.
+
+**Carve-outs (do NOT penalize):**
+- `relevant` in a markdown header (e.g., `## Relevant X`).
+- `relevant to <named-scope>` constructions (semantic "pertinent to").
+- Any term followed by a measurable criterion clause (e.g., "appropriate to the SLO target of 99.9% uptime").
+
+See `nlpm:scoring` for the full vague-quantifier penalty table and cap (-2 each, -20 cap).
+
+---
+
+## 5. Naming Conventions (universal)
 
 | Item | Convention | Example |
-|------|-----------|---------|
+|---|---|---|
 | File names | kebab-case | `tdd-guardian.md`, `pre-write-check.sh` |
-| Plugin names | kebab-case | `nlpm`, `echo-sleuth` |
+| Plugin/package names | kebab-case | `nlpm`, `echo-sleuth` |
 | Skill references | `plugin-name:skill-name` | `nlpm:conventions`, `tdd-guardian:rules` |
 | Rule files (ordered) | `NN-kebab.md` | `01-formatting.md` |
-| Environment variable | SCREAMING_SNAKE | `CLAUDE_PLUGIN_ROOT` |
+| Environment variables | SCREAMING_SNAKE | `OPENAI_API_KEY`, `CLAUDE_PLUGIN_ROOT` |
+| Plugin directory env vars | `<TOOL>_PLUGIN_ROOT` | `CLAUDE_PLUGIN_ROOT`, `CODEX_PLUGIN_ROOT` |
 
-**Portable paths:** Always use `${CLAUDE_PLUGIN_ROOT}` when referencing files within a plugin (scripts, configs). Hardcoded absolute paths break portability.
+**Portable paths:** Within a plugin, always reference files via the tool's plugin-root environment variable (e.g., `${CLAUDE_PLUGIN_ROOT}` for Claude, equivalent for Codex). Hardcoded absolute paths break portability.
 
----
-
-## 11. Reference Syntax
-
-**Commands referencing shared partials:**
-```
-<!-- Include: commands/shared/discover.md -->
-```
-Or by instruction: "Follow the steps in commands/shared/discover.md"
-
-**Agents referencing skills in frontmatter:**
-```yaml
-skills: ["nlpm:conventions", "nlpm:patterns"]
-```
-
-**Hooks referencing scripts:**
-```json
-"command": "${CLAUDE_PLUGIN_ROOT}/scripts/check.sh"
-```
-
-**Cross-plugin skill references** use the same `plugin:skill` format. The plugin must be installed for the reference to resolve.
+Tool-specific naming details (e.g., the exact `CLAUDE_PLUGIN_ROOT` semantics) live in the per-tool overlays.
 
 ---
 
-## 12. Memory File Conventions
+## 6. Rule Overrides (`.claude/nlpm.local.md` or equivalent)
 
-Memory files are `.md` files that Claude Code writes and reads as persistent per-project knowledge.
+The override system is universal. The configuration file path is per-tool:
 
-**Location:**
-```
-~/.claude/projects/<project-slug>/memory/
-```
+| Tool | Config path |
+|---|---|
+| Claude Code | `.claude/nlpm.local.md` |
+| Codex CLI | `.codex/nlpm.local.md` |
+| Antigravity | `.gemini/nlpm.local.md` (or `.agent/nlpm.local.md` — TBD post-2026-06-18) |
 
-**Index file:** `MEMORY.md` lives at the same level as individual memory files. It is a one-line-per-entry index, not a memory file itself. Each line references one memory file by filename.
-
-**Individual memory files** MUST include YAML frontmatter:
-
-```yaml
----
-name: "short identifier"
-description: "one-line summary of what this memory contains"
-type: user | feedback | project | reference
----
-```
-
-**`type` values:**
-| Value | Meaning |
-|-------|---------|
-| `user` | Preferences, habits, or facts about the user |
-| `feedback` | Corrections or lessons from past sessions |
-| `project` | Project-specific facts, decisions, or context |
-| `reference` | External reference material copied into memory |
-
-**Rules:**
-- Every memory file must appear in `MEMORY.md` — orphaned files (present in the directory but not in the index) are flagged by the scorer
-- `MEMORY.md` itself is the index; it does not need frontmatter and is not scored as a memory file
-- Memory files should not reference other files or functions that have since been deleted — stale references reduce the signal-to-noise ratio of the memory store
-
----
-
-## 13. Rule Overrides in nlpm.local.md
-
-Users can suppress or adjust individual rules in `.claude/nlpm.local.md`:
+Frontmatter format (identical across tools):
 
 ```yaml
 ---
@@ -444,51 +173,40 @@ rule_overrides:
   R09: { min_examples: 1 }      # require only 1 example block instead of 2
   R10: { suppress: true }       # disable model tier checking entirely
   R23: { budget: 800 }          # increase rules budget from 500 to 800 lines
+  R51: { enabled: true, vocabulary_skill: skills/myplugin/vocabulary/ }
 ---
 ```
 
 **Override types:**
 
 | Type | Effect | Example |
-|------|--------|---------|
-| `suppress: true` | Disable the rule entirely (penalty becomes 0) | `R10: { suppress: true }` |
-| `enabled: true` | Activate a rule that ships **disabled by default** (currently only R51) | `R51: { enabled: true, vocabulary_skill: skills/myplugin/vocabulary/ }` |
-| `max_penalty: N` | Cap the penalty at N (less negative = more lenient) | `R01: { max_penalty: -10 }` |
-| `threshold: N` | Adjust numeric thresholds (line limits, counts) | `R05: { threshold: 600 }` |
+|---|---|---|
+| `suppress: true` | Disable the rule (penalty becomes 0) | `R10: { suppress: true }` |
+| `enabled: true` | Activate a rule that ships disabled by default (currently only R51) | `R51: { enabled: true, vocabulary_skill: ... }` |
+| `max_penalty: N` | Cap the penalty (less negative = more lenient) | `R01: { max_penalty: -10 }` |
+| `threshold: N` | Adjust numeric thresholds | `R05: { threshold: 600 }` |
 | `min_examples: N` | Adjust minimum example counts | `R09: { min_examples: 1 }` |
-| `vocabulary_skill: <path>` | Path to the project's `vocabulary` skill (R51 only). Without it, R51 emits an advisory and contributes zero penalty. | `R51: { enabled: true, vocabulary_skill: skills/myplugin/vocabulary/ }` |
+| `vocabulary_skill: <path>` | Path to project's `vocabulary` skill (R51 only) | `R51: { enabled: true, vocabulary_skill: ... }` |
 
 Rules not listed in `rule_overrides` use their defaults from `nlpm:scoring`. Rules that ship disabled (R51) contribute zero penalty unless `enabled: true` is set explicitly.
 
 ---
 
-## 14. Claude Code Tool Catalog
+## 7. Universal Tool References
 
-The following tool names are valid in `tools:` and `allowed-tools:` fields.
-Do NOT flag any of these as "undocumented" or "unknown".
+**MCP tools** follow the cross-tool pattern: `mcp__<server-name>__<tool-name>`. Example: `mcp__mermaider__validate_syntax`.
 
-**Built-in tools:**
-- File I/O: `Read`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit`
-- Discovery: `Glob`, `Grep`
-- Execution: `Bash`, `BashOutput`, `KillBash`
-- Agent: `Task`
-- Web: `WebFetch`, `WebSearch`
-- User interaction: `AskUserQuestion`
-- Planning: `TodoWrite`
-- Commands: `SlashCommand`
-
-**MCP tools follow the pattern:** `mcp__<server-name>__<tool-name>`
-Example: `mcp__mermaider__validate_syntax`, `mcp__codex__codex`
-
-Tool names are case-sensitive. Any string matching the patterns above is
-a valid tool reference regardless of whether this document pre-dates the
-tool's introduction to Claude Code.
+Per-tool built-in tool catalogs live in the overlays:
+- Claude Code built-ins → `nlpm:conventions-claude` §16
+- Codex CLI built-ins → `nlpm:conventions-codex`
+- Antigravity built-ins → `nlpm:conventions-antigravity`
 
 ---
 
 ## Scope Note
 
-This skill covers Claude Code plugin component schemas and conventions. It does NOT cover:
-- Scoring/quality rubric -> see `nlpm:scoring`
-- Anti-patterns and best practices catalog -> see `nlpm:patterns`
-- General software engineering conventions outside Claude Code artifacts
+This skill covers the universal floor — conventions that apply regardless of which tool the artifact targets. It does NOT cover:
+- Tool-specific schemas → see `nlpm:conventions-claude` / `nlpm:conventions-codex` / `nlpm:conventions-antigravity`
+- Penalty tables → see `nlpm:scoring`
+- Anti-patterns and best practices catalog → see `nlpm:patterns`
+- General software engineering conventions outside NL programming artifacts

--- a/skills/nlpm/scoring/SKILL.md
+++ b/skills/nlpm/scoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scoring
 description: "Use when scoring NL artifact quality, applying penalties, or calibrating lint judgment — contains the 100-point rubric with penalty tables per artifact type and 4 worked calibration examples."
-version: 0.2.1
+version: 0.3.0
 ---
 
 # NLPM Quality Scoring Rubric
@@ -114,21 +114,49 @@ Penalties stack. The floor is 0; the ceiling is 100. No bonuses — the default 
 
 ---
 
-### Hooks
+### Hooks — universal checks (apply to all tools)
 
 | Rule | Check | Condition | Penalty |
 |------|-------|-----------|---------|
-| -- | Valid JSON | hooks.json fails JSON parse | -25 |
-| R27 | Event names valid | Uses unrecognized event name | -15 |
-| R27 | Case correct | Event name has wrong case (e.g. `pretooluse`) | -10 |
+| -- | Valid syntax | Hook config file fails to parse (JSON or TOML per tool) | -25 |
 | R29 | Scripts exist | Referenced script file does not exist | -20 |
-| -- | Command safety | Hook command contains dangerous patterns (rm -rf, git push --force, DROP TABLE) | -15 |
+| -- | Command safety | Hook command contains dangerous patterns (`rm -rf`, `git push --force`, `DROP TABLE`) | -15 |
 | -- | Matcher regex valid | Matcher pattern doesn't compile as valid regex | -10 |
 | -- | Timeout reasonable | Hook specifies timeout > 30s (likely hangs) | -5 |
 
+### Hooks (Claude Code — Tier 2-Claude only)
+
+Authoritative event list: `nlpm:conventions-claude` §7. Per the multi-tool design (`analysis/multi-tool-design-2026-05.md` decision #4), Claude / Codex / Antigravity hook event vocabularies are NOT 1:1 mappable — three separate tables, no translation.
+
+| Rule | Check | Condition | Penalty |
+|------|-------|-----------|---------|
+| R27 | Event names valid (Claude) | Uses unrecognized event name — confirmed Claude events: `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `Stop`, `StopFailure`, `FileChanged` | -15 |
+| R27 | Case correct (Claude) | Event name has wrong case (e.g. `pretooluse`) | -10 |
+| -- | Hook type valid (Claude) | Uses unrecognized `type` value — confirmed Claude types: `command`, `http`, `mcp_tool`, `prompt`, `agent` | -10 |
+| -- | MCP matcher format (Claude) | Matcher targets MCP tool but doesn't use `mcp__<server>__<tool>` pattern | -5 |
+
+### Hooks (Codex CLI — Tier 2-Codex only)
+
+Authoritative event list: `nlpm:conventions-codex` §6.
+
+| Rule | Check | Condition | Penalty |
+|------|-------|-----------|---------|
+| R27 | Event names valid (Codex) | Uses unrecognized event name — confirmed Codex events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PermissionRequest`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`, `Stop` | -15 |
+| R27 | Case correct (Codex) | Event name has wrong case | -10 |
+| -- | Hooks config key (Codex) | `config.toml` uses deprecated `[features].codex_hooks` instead of `[features].hooks` (renamed ~CLI 0.129+) | -5 (advisory) |
+
+### Hooks (Antigravity / Gemini lineage — Tier 2-Antigravity only) — ADVISORY
+
+Authoritative event list: `nlpm:conventions-antigravity` §5. **All Antigravity-specific hook scoring is advisory-only** (confidence:low) until the Antigravity 2.0 spec stabilizes — see `analysis/multi-tool-design-2026-05.md` decision #3.
+
+| Rule | Check | Condition | Penalty |
+|------|-------|-----------|---------|
+| R27 | Event names valid (Gemini lineage) | Uses unrecognized event name — confirmed events: `SessionStart`, `BeforeAgent`, `BeforeModel`, `BeforeToolSelection`, `BeforeTool`, `AfterTool`, `AfterModel`, `AfterAgent`, `SessionEnd`, `Notification`, `PreCompress` | -10 (advisory) |
+| R27 | Case correct (Gemini lineage) | Event name has wrong case | -5 (advisory) |
+
 ---
 
-### plugin.json
+### plugin.json (Claude Code — `.claude-plugin/plugin.json`)
 
 | Check | Condition | Penalty |
 |-------|-----------|---------|
@@ -138,12 +166,110 @@ Penalties stack. The floor is 0; the ceiling is 100. No bonuses — the default 
 
 ---
 
-### .mcp.json
+### .codex-plugin/plugin.json (Codex CLI — Tier 2-Codex only)
+
+Schema reference: `nlpm:conventions-codex` §3.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid JSON | File fails JSON parse | -25 |
+| `name` present | Missing | -25 |
+| `name` kebab-case | Mixed case or underscores | -10 |
+| `version` is semver | Present but not valid semver | -10 |
+| `description` present | Missing | -5 |
+| Component paths relative | `skills`/`mcpServers`/`apps`/`hooks` paths absolute or missing `./` prefix | -5 each |
+
+---
+
+### .agents/plugins/marketplace.json (Codex marketplace — Tier 2-Codex)
+
+Schema reference: `nlpm:conventions-codex` §4. Schema is largely compatible with Claude's `.claude-plugin/marketplace.json`.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid JSON | File fails JSON parse | -25 |
+| `name` present | Missing | -25 |
+| `plugins` array present | Missing or empty | -10 |
+| Per-plugin `source` valid | `source.source` not in `github`/`git`/`local`, or required `repo`/`path` missing | -10 each |
+| Per-plugin `category` present | Missing (informational, helps marketplace navigation) | -3 each |
+
+---
+
+### agents/openai.yaml (Codex skill sidecar — Tier 2-Codex)
+
+Schema reference: `nlpm:conventions-codex` §2.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid YAML | File fails YAML parse | -25 |
+| Sidecar is colocated | `agents/openai.yaml` not in same directory as a `SKILL.md` | -10 |
+| `interface.display_name` present | Missing | -5 (informational) |
+
+---
+
+### gemini-extension.json (Gemini/Antigravity — Tier 2-Antigravity) — ADVISORY
+
+Schema reference: `nlpm:conventions-antigravity` §3. **All Antigravity-specific manifest scoring is advisory-only** until the post-2026-06-18 Antigravity spec stabilizes.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid JSON | File fails JSON parse | -25 |
+| `name` present | Missing | -25 |
+| `version` present | Missing | -10 |
+| `contextFileName` includes `AGENTS.md` | Single-tool projects use only `GEMINI.md`; multi-tool should include `AGENTS.md` | -3 (advisory; multi-tool nudge) |
+
+---
+
+### .gemini/commands/*.toml (Gemini slash commands — legacy/transitional, Tier 2-Antigravity)
+
+Schema reference: `nlpm:conventions-antigravity` §4.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid TOML | File fails TOML parse | -25 |
+| `prompt` field present | Missing required field | -25 |
+| `description` field present | Missing (auto-generated from filename, but explicit is better) | -3 |
+
+---
+
+### .mcp.json (Claude Code — `.mcp.json` at repo root)
 
 | Check | Condition | Penalty |
 |-------|-----------|---------|
 | Valid JSON | File fails JSON parse | -25 |
 | Server `command` present | MCP server entry missing `command` field | -15 |
+
+---
+
+### .codex/config.toml (Codex configuration — Tier 2-Codex)
+
+Schema reference: `nlpm:conventions-codex` §5.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid TOML | File fails TOML parse | -25 |
+| Deprecated `[features].codex_hooks` | Should be `[features].hooks` (renamed ~CLI 0.129) | -5 (advisory) |
+| Per-MCP `command` present | `[mcp_servers.<id>]` table missing `command` field | -15 each |
+
+---
+
+### .lsp.json (Claude Code LSP — Tier 2-Claude)
+
+Schema details: `nlpm:conventions-claude` §12. Stable in 2026.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid JSON | File fails JSON parse | -25 |
+
+---
+
+### monitors/monitors.json (Claude Code monitors — Tier 2-Claude)
+
+Schema details: `nlpm:conventions-claude` §13. Stable in 2026.
+
+| Check | Condition | Penalty |
+|-------|-----------|---------|
+| Valid JSON | File fails JSON parse | -25 |
 
 ---
 
@@ -403,9 +529,14 @@ This skill covers the NLPM scoring formula, penalty tables, score bands, and cal
 - Patterns and anti-patterns catalog → see `nlpm:patterns`
 - How to run the score command → see `commands/score.md`
 
-### Multi-tool scoring (in progress, 2026-05-25)
+### Multi-tool scoring (PR-B landed 2026-05-25)
 
-nlpm is moving from Claude-Code-only to multi-tool coverage (Claude Code + Codex CLI + Antigravity). The Tier classification in `agents/scorer.md` already separates open-spec, Tier 1.5 open-spec corpora, and Tier 2 per-tool overlays (2-Claude / 2-Codex / 2-Antigravity). PR-B will split the Hooks penalty table into per-tool tables (the three tools' event vocabularies are not 1:1-mappable, by design — see the design doc) and add new rows for `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `gemini-extension.json`, `agents/openai.yaml` sidecars, LSP, Monitors, and new Claude SKILL.md fields (`context: fork`, `agent:`, `paths:` glob scoping, skill-scoped `hooks:`, etc.). Until PR-B lands, Tier 2-Codex and Tier 2-Antigravity artifacts are detected but scored at the universal floor only.
+nlpm now scores artifacts across three tool ecosystems — Claude Code, Codex CLI, and Antigravity (which absorbs Gemini CLI on 2026-06-18). The tier classification in `agents/scorer.md` separates open-spec (Tier 1), Tier 1.5 open-spec corpora, and per-tool Tier 2 overlays (2-Claude / 2-Codex / 2-Antigravity).
+
+- **Hooks** are scored per tool (Claude / Codex / Antigravity tables above). The three tools' event vocabularies are not 1:1 mappable; no universal translation layer. See `analysis/multi-tool-design-2026-05.md` decision #4.
+- **Codex-specific artifacts** scored: `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `.codex/config.toml`, `agents/openai.yaml` sidecars.
+- **Antigravity-specific artifacts** scored (advisory-only until spec stabilizes): `gemini-extension.json`, `.gemini/commands/*.toml`, Antigravity hook events.
+- **Claude-specific additions** in 2026: `.lsp.json`, `monitors/monitors.json` (validate JSON-parse only until detailed schemas land). New SKILL.md fields documented in `nlpm:conventions-claude`.
 
 ### Known False Positive Patterns
 


### PR DESCRIPTION
## Summary

**PR-B of three** in the multi-tool arc (PR-A landed the foundation; PR-C does the auditor pipeline and repo rename). Lands the content migration designed in \`analysis/multi-tool-design-2026-05.md\`.

\`nlpm:conventions\` splits into **four skills** (universal floor + three per-tool overlays). The scoring rubric grows per-tool Hooks tables and new artifact rows for the Codex and Antigravity surfaces.

## The split

| Skill | Status | Content |
|---|---|---|
| \`nlpm:conventions\` | **slimmed** | Universal floor — SKILL.md open spec, AGENTS.md as canonical universal memory, R01 vague quantifiers, prompt engineering, naming, override system |
| \`nlpm:conventions-claude\` | **new** | Claude Code overlay — \`.claude/\` paths, plugin.json, hook events (with 9 confirmed events from 2026-05 refresh), 5 hook types, LSP, monitors, settings, the merged commands/skills surface, v2.1.x SKILL.md fields (\`context: fork\`, \`agent:\`, \`paths:\`, skill-scoped \`hooks:\`, etc.), tool catalog |
| \`nlpm:conventions-codex\` | **new** | Codex CLI overlay — \`.agents/\` vs \`.codex/\` split, \`.codex-plugin/plugin.json\`, \`.agents/plugins/marketplace.json\` (3 marketplace tiers), \`.codex/config.toml\` sections, \`agents/openai.yaml\` sidecar, Codex hook events, AGENTS.md hierarchy, breaking changes (0.129 hooks rename, 0.131 built-in MCP removal) |
| \`nlpm:conventions-antigravity\` | **new (advisory)** | Antigravity + legacy Gemini overlay — Gemini-lineage hook events (Before/After Agent/Model/Tool decomposition), \`.gemini/\` legacy paths, \`.agent/\` workspace skills, TOML slash commands, \`gemini-extension.json\`, GEMINI.md with \`context.fileName\` interop hook, transition timeline (Gemini sunset 2026-06-18). Major uncertainties flagged. |

## Scoring rubric updates

- **Hooks table splits** into a universal-checks table + three per-tool tables (Claude / Codex / Antigravity-advisory). Per decision #4 (no universal hook-event translation — the three vocabularies are not 1:1 mappable).
- **New artifact-type tables**: \`.codex-plugin/plugin.json\`, \`.agents/plugins/marketplace.json\`, \`agents/openai.yaml\` sidecar, \`gemini-extension.json\`, \`.gemini/commands/*.toml\`, \`.codex/config.toml\`, \`.lsp.json\`, \`monitors/monitors.json\`.
- **Antigravity-specific findings** marked \`confidence:low\` (advisory) — won't gate contributions, will surface in audits.
- Version: \`nlpm:scoring\` 0.2.1 → 0.3.0; \`nlpm:conventions\` 0.1.0 → 0.2.0.

## Agent + AGENTS.md updates

- \`agents/scorer.md\` and \`agents/checker.md\` declare all four conventions skills in \`skills:\` frontmatter (eager-loaded — see design doc for the token-cost vs simplicity tradeoff).
- \`agents/scorer.md\` removes PR-A's "forward reference" staging notes (the overlays now exist).
- \`AGENTS.md\` skill section lists the four conventions sub-skills with their roles.

## Backward compatibility

- **Claude-shaped audits** continue identically. The Claude-specific content moved from \`conventions\` to \`conventions-claude\`, but both are loaded by the scorer — net content is the same.
- **Codex-shaped audits** now have a real rubric (was universal-floor-only between PR-A and PR-B).
- **Antigravity-shaped audits** get advisory-only findings (won't change PR-shipping behavior, will appear in audit reports for self-learning).
- The \`bin/nlpm-check\` standalone binary is unaffected — it validates the universal floor only.

## Validation

- \`python3 -m unittest tests.test_nlpm_check\` — 23/23 pass.
- Per the design doc's PR-B trigger conditions, conventions-antigravity is explicitly advisory until Antigravity 2.0's directory layout stabilizes (the singular \`.agent/\` vs plural \`.agents/\` inconsistency between authoritative sources is recorded for verification).

## What comes next

**PR-C** will close the loop:
- \`auditor-discover.yml\` adds two parallel \`gh search repos\` queries (Codex-shaped, Antigravity-shaped).
- Vendor-default filter adds OpenAI-CLA check (research before merging).
- Security scanner recognizes Codex MCP TOML and Antigravity hook events.
- Per-tool exemplar gallery views; \`tool:\` frontmatter field on exemplars.
- Repo rename: \`nlpm-for-claude\` → \`nlpm\`.
- Plugin major version bump 0.8.x → 1.0.0 (multi-tool branded release).
- Coordinated marketplace updates: plugin's own \`marketplace.json\`, central Claude marketplace, central Codex marketplace, README version tables.

## Test plan

- [ ] Next audit on a Claude-shaped repo: confirm scoring unchanged.
- [ ] Next audit on a Codex-shaped repo: confirm Codex-specific findings now appear with correct rule labels (\`.codex-plugin/plugin.json\`, \`agents/openai.yaml\`).
- [ ] Next audit on \`google/skills\` or similar open-spec corpus: confirm Tier 1.5 classification still works (the wider marker check shouldn't change Tier 1.5 behavior).
- [ ] Self-audit on nlpm: confirm the four conventions sub-skills score well as Tier 2-Claude (it's nlpm's own home tool).