### PR TITLE
multi-tool PR-C: v1.0.0 + multi-tool positioning + rename prep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,14 +11,14 @@
       "name": "nlpm",
       "source": {
         "source": "github",
-        "repo": "xiaolai/nlpm-for-claude"
+        "repo": "xiaolai/nlpm"
       },
-      "description": "Natural-Language Programming Manager \u2014 scan, lint, and write NL artifacts with Claude-native quality scoring",
-      "version": "0.8.23",
+      "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
+      "version": "1.0.0",
       "author": {
         "name": "xiaolai"
       },
-      "repository": "https://github.com/xiaolai/nlpm-for-claude",
+      "repository": "https://github.com/xiaolai/nlpm",
       "license": "ISC",
       "keywords": [
         "nlp",
@@ -27,7 +27,11 @@
         "skill",
         "agent",
         "rules",
-        "quality"
+        "quality",
+        "claude",
+        "codex",
+        "antigravity",
+        "multi-tool"
       ],
       "category": "developer-tools"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "nlpm",
-  "version": "0.8.23",
-  "description": "Natural-Language Programming Manager — scan, lint, and write NL artifacts with Claude-native quality scoring",
+  "version": "1.0.0",
+  "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"
   },
   "license": "ISC",
   "homepage": "https://nlpm.com",
-  "repository": "https://github.com/xiaolai/nlpm-for-claude",
+  "repository": "https://github.com/xiaolai/nlpm",
   "category": "developer-tools",
   "keywords": [
     "nlp",
@@ -16,6 +16,10 @@
     "skill",
     "agent",
     "rules",
-    "quality"
+    "quality",
+    "claude",
+    "codex",
+    "antigravity",
+    "multi-tool"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 # nlpm
 
-Natural-Language Programming Manager for Claude Code.
+Natural-Language Programming Manager — multi-tool (Claude Code, Codex CLI, Antigravity) NL artifact scoring, checking, fixing, and testing. Delivered as a Claude Code plugin; the scoring rubric covers all three ecosystems via tier-aware overlays (see `analysis/multi-tool-design-2026-05.md`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # nlpm
 
-[![Validated by NLPM](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xiaolai/nlpm-for-claude/main/nlpm-badge.json)](https://github.com/xiaolai/nlpm-for-claude/blob/main/nlpm-badge.json)
+[![Validated by NLPM](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xiaolai/nlpm/main/nlpm-badge.json)](https://github.com/xiaolai/nlpm/blob/main/nlpm-badge.json)
 
-Natural-Language Programming Manager -- discover, score, check, and fix NL artifacts with Claude-native intelligence.
+Natural-Language Programming Manager — score, check, fix, and test NL artifacts across **Claude Code, Codex CLI, and Antigravity**. Tier-aware scoring with per-tool overlays.
 
-Part of the [xiaolai Claude plugin marketplace](https://github.com/xiaolai/claude-plugin-marketplace).
+Part of the [xiaolai plugin marketplace](https://github.com/xiaolai/claude-plugin-marketplace).
 
-NLPM is the only validator in the Claude Code plugin ecosystem that systematically checks **manifest-vs-disk consistency** — the bug class where a SKILL.md exists on disk but is silently missing from `plugin.json` (and therefore invisible after `claude plugin install`). Verified across 8+ tools including Anthropic's official `plugin-validator` and the Linux Foundation's `skills-ref`. See [`analysis/ecosystem-gap.md`](analysis/ecosystem-gap.md) for the research.
+NLPM is the only multi-tool NL artifact validator that systematically checks **manifest-vs-disk consistency** — the bug class where a SKILL.md exists on disk but is silently missing from `plugin.json` (and therefore invisible after `claude plugin install`). Verified across 8+ tools including Anthropic's official `plugin-validator` and the Linux Foundation's `skills-ref`. See [`analysis/ecosystem-gap.md`](analysis/ecosystem-gap.md) for the research.
 
 ## What it does
 
@@ -25,7 +25,7 @@ Eight commands, each doing one thing:
 | `/nlpm:init` | Initialize NLPM for a project |
 | `/nlpm:security-scan` | Scan plugins for security risks in executable artifacts |
 
-Claude-native slash commands (no API keys, no Codex, no external models) plus a standalone Python 3.11+ validator for pre-commit hooks and CI.
+Slash commands ship as a Claude Code plugin. The scoring rubric covers three ecosystems (Claude Code, Codex CLI, Antigravity) via tier-aware overlays — see [`analysis/multi-tool-design-2026-05.md`](analysis/multi-tool-design-2026-05.md). The standalone Python 3.11+ validator (`bin/nlpm-check`) has no Claude Code dependency and runs in pre-commit hooks or CI on any tool's artifacts.
 
 ### Beyond linting: the learning loop
 
@@ -67,7 +67,7 @@ From CI or a pre-commit hook (no Claude Code required):
 
 ```bash
 curl -fsSL -o /usr/local/bin/nlpm-check \
-  https://raw.githubusercontent.com/xiaolai/nlpm-for-claude/main/bin/nlpm-check
+  https://raw.githubusercontent.com/xiaolai/nlpm/main/bin/nlpm-check
 chmod +x /usr/local/bin/nlpm-check
 nlpm-check .               # exit 1 on high-confidence findings
 ```
@@ -79,7 +79,7 @@ If you author a plugin and want NLPM in your **pre-commit hook, CI, or pre-publi
 ```bash
 # One-line install
 curl -fsSL -o /usr/local/bin/nlpm-check \
-  https://raw.githubusercontent.com/xiaolai/nlpm-for-claude/main/bin/nlpm-check
+  https://raw.githubusercontent.com/xiaolai/nlpm/main/bin/nlpm-check
 chmod +x /usr/local/bin/nlpm-check
 
 # Run in your plugin repo


### PR DESCRIPTION
## Summary

**PR-C of three** in the multi-tool arc. Closes the codebase work for the de-Claude-ification by bumping to **v1.0.0** and updating all user-visible positioning to reflect that nlpm now scores artifacts across **Claude Code, Codex CLI, and Antigravity** via tier-aware overlays (PR-B's split).

The GitHub repo rename (\`xiaolai/nlpm-for-claude\` → \`xiaolai/nlpm\`) executes as a follow-up shell action after this PR merges; GitHub auto-redirects from the old URL during the cutover window. This PR pre-positions all references to the new URL so post-rename the codebase is already consistent.

## What changes

- \`.claude-plugin/plugin.json\` — v0.8.23 → **v1.0.0**, description reflects multi-tool, repository → \`xiaolai/nlpm\`, keywords add \`claude\`, \`codex\`, \`antigravity\`, \`multi-tool\`.
- \`.claude-plugin/marketplace.json\` — same updates to this plugin's own marketplace entry.
- \`README.md\` — badge URL + install URLs → \`xiaolai/nlpm\`; tagline reflects multi-tool scope; "Claude-native slash commands" clarified — slash commands ship as a Claude Code plugin, but the rubric covers three ecosystems and \`bin/nlpm-check\` is tool-agnostic.
- \`AGENTS.md\` — project description from "for Claude Code" to multi-tool.

## What's preserved as-is

- **Historical audit reports** (\`auditor/audits/xiaolai-nlpm-for-claude.md\`, etc.) keep the old slug — audit slugs derive from the GitHub repo path at audit time and aren't retroactively rewritten. Future audits will use \`xiaolai-nlpm\` slugs naturally.
- **Slash commands** are still Claude-Code-only (commands run inside Claude Code). What's now multi-tool is the **rubric and the standalone validator**, not the delivery mechanism.

## Deferred to follow-ups

1. **\`gh repo rename xiaolai/nlpm-for-claude nlpm\`** + local git remote update — happens immediately after merge, not in this PR.
2. **Central marketplace propagation** at \`xiaolai/claude-plugin-marketplace\` — updates \`.claude-plugin/marketplace.json\` (and \`.agents/plugins/marketplace.json\` if/when a Codex layout exists) and the README version table.
3. **Auditor pipeline multi-tool discovery** (\`auditor-discover.yml\` + \`vendor_default_filter.py\`) — needs careful gh-search query design and CLA-policy research; deferred to a focused PR.
4. **Codex plugin layout** for nlpm itself (run \`build-codex.mjs\`) — defer until the multi-tool rubric is exercised on real Codex repos.

## Validation

- \`python3 -m unittest tests.test_nlpm_check\` — 23/23 pass.
- All URL updates are mechanical string replacements; no behavioral code change.
- v1.0.0 is the right semver bump: the conventions/scoring/tier model changed structurally; existing Claude-shaped audits continue to work identically.

## Test plan

- [ ] After merge, run \`gh repo rename xiaolai/nlpm-for-claude nlpm\` and confirm GitHub redirects from the old URL.
- [ ] Update local git remote: \`git remote set-url origin https://github.com/xiaolai/nlpm.git\`.
- [ ] Update central marketplace entries (4 places per the release workflow).
- [ ] Run \`claude plugin marketplace update xiaolai\` and verify \`claude plugin install nlpm@xiaolai\` resolves to v1.0.0.