### PR TITLE
docs: writing-* + patterns skills multi-tool catch-up (Option B)

### DIFF
--- a/skills/nlpm/patterns/SKILL.md
+++ b/skills/nlpm/patterns/SKILL.md
@@ -6,7 +6,7 @@ version: 0.1.0
 
 # NL Programming Patterns
 
-Best practices and anti-patterns for writing Claude Code plugin components. Each pattern includes a rationale and a concrete example. Use this skill when authoring or reviewing skills, agents, commands, rules, or hooks.
+Best practices and anti-patterns for writing NL programming artifacts (Claude Code, Codex CLI, Antigravity). Each pattern includes a rationale and a concrete example. The patterns are tool-agnostic — they describe how to write effective natural-language instructions, not tool-specific schemas. Use this skill when authoring or reviewing skills, agents, commands, rules, or hooks.
 
 ---
 
@@ -244,7 +244,7 @@ Absolute paths in hooks, scripts, or plugin configs break when:
 
 ## Scope Note
 
-This skill covers NL programming patterns and anti-patterns for Claude Code artifacts. It does NOT cover:
+This skill covers NL programming patterns and anti-patterns for artifacts across Claude Code, Codex CLI, and Antigravity. It does NOT cover:
 - Exact schema fields and syntax → see `nlpm:conventions`
 - Scoring rubric with penalty tables → see `nlpm:scoring`
-- General software engineering patterns outside Claude Code
+- General software engineering patterns outside NL programming artifacts

--- a/skills/nlpm/writing-agents/SKILL.md
+++ b/skills/nlpm/writing-agents/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: writing-agents
 description: "How to write Claude Code agents that trigger reliably, use the right model, and produce consistent output. Use when creating, improving, or reviewing agent definitions."
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Writing Agents
 
-> Scope: covers agent `.md` file authoring. For multi-agent orchestration, see [[orchestration]]. For plugin architecture, see [[writing-plugins]].
+> Scope: covers Claude Code agent `.md` file authoring (Markdown + frontmatter at `.claude/agents/`). Codex CLI defines agents differently — as `[agents.<name>]` TOML tables in `.codex/config.toml`; see [[nlpm:conventions-codex]]. Antigravity subagents are under-documented at this writing; see [[nlpm:conventions-antigravity]]. For multi-agent orchestration, see [[orchestration]]. For plugin architecture, see [[writing-plugins]].
 
 ## 1. Example Blocks Make or Break Triggering
 

--- a/skills/nlpm/writing-hooks/SKILL.md
+++ b/skills/nlpm/writing-hooks/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: writing-hooks
 description: "How to write Claude Code hooks -- event selection, hook types, matcher patterns, blocking vs advisory, portable paths. Use when creating hooks for quality gates, automation, or policy enforcement."
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Writing Hooks
 
-> Scope: covers hooks.json authoring and hook script design. For plugin architecture, see [[writing-plugins]]. For rules (which are simpler but static), see [[writing-rules]].
+> Scope: covers Claude Code `hooks.json` authoring and hook script design. **Hook event vocabularies are per-tool and NOT 1:1 mappable** (nlpm design decision #4): Claude uses `PreToolUse`/`PostToolUse`/`Stop`/etc.; Codex overlaps with Claude plus `PostCompact`/`SubagentStart`; Antigravity/Gemini uses a different `Before*/After* Agent/Model/Tool` decomposition. The hook-script design principles here (idempotency, fail-open, exit codes, portable paths) transfer across tools; the event names and config locations do not. For the authoritative per-tool event tables see [[nlpm:conventions-claude]] §7, [[nlpm:conventions-codex]] §6, [[nlpm:conventions-antigravity]] §5. For plugin architecture, see [[writing-plugins]]. For rules (which are simpler but static), see [[writing-rules]].
 
 ## 1. Three Hook Types
 

--- a/skills/nlpm/writing-plugins/SKILL.md
+++ b/skills/nlpm/writing-plugins/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: writing-plugins
-description: "How to design and build Claude Code plugins -- architecture decisions, component selection, file structure, manifest configuration, marketplace publishing. Use when planning, creating, or reviewing a Claude Code plugin."
-version: 0.1.0
+description: "How to design and build plugins -- architecture decisions, component selection, file structure, manifest configuration, marketplace publishing. Primarily Claude Code (.claude-plugin/plugin.json); the same architecture maps to Codex CLI (.codex-plugin/plugin.json) and Antigravity extensions. Use when planning, creating, or reviewing a plugin."
+version: 0.2.0
 ---
 
 # Writing Plugins
 
-> Scope: covers plugin design and architecture. For individual component authoring, see [[writing-skills]], [[writing-agents]], [[writing-hooks]], [[writing-rules]].
+> Scope: covers plugin design and architecture. The examples use the **Claude Code** layout (`.claude-plugin/plugin.json` + auto-discovered `commands/`, `agents/`, `skills/`, `hooks/`). The same component-selection and architecture reasoning maps to the other tools — only the manifest path and packaging differ:
+> - **Codex CLI**: `.codex-plugin/plugin.json` manifest + `.agents/plugins/marketplace.json`; skills live at `.agents/skills/`. See [[nlpm:conventions-codex]].
+> - **Antigravity**: `gemini-extension.json` (becoming "Antigravity plugins"); skills at `.agent/skills/`. See [[nlpm:conventions-antigravity]].
+> - **Cross-tool skills**: a `SKILL.md` collection with no plugin wrapper installs into any tool via `npx skills add`. See [[writing-skills]].
+>
+> For individual component authoring, see [[writing-skills]], [[writing-agents]], [[writing-hooks]], [[writing-rules]].
 
 ## 1. Plugin = Commands + Agents + Skills + Hooks
 

--- a/skills/nlpm/writing-rules/SKILL.md
+++ b/skills/nlpm/writing-rules/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: writing-rules
 description: "How to write .claude/rules/ files that Claude actually follows. Use when creating, improving, or reviewing project rules."
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Writing Rules
 
-> Scope: covers `.claude/rules/` file authoring. For CLAUDE.md conventions, see [[writing-plugins]]. For system prompts generally, see [[writing-prompts]].
+> Scope: covers `.claude/rules/` file authoring — a **Claude-Code-specific** concept (path-scoped, always-loaded instruction files with `paths:` glob frontmatter). Codex CLI and Antigravity have no exact `.claude/rules/` equivalent; their always-on project instructions live in the hierarchical memory file (`AGENTS.md` for Codex, `GEMINI.md` for Antigravity — both can be pointed at the canonical `AGENTS.md`; see [[nlpm:conventions-codex]] / [[nlpm:conventions-antigravity]]). The bold-imperative-plus-rationale writing technique here applies to any tool's instruction files. For CLAUDE.md / AGENTS.md conventions, see [[writing-plugins]]. For system prompts generally, see [[writing-prompts]].
 
 ## 1. The Golden Format
 

--- a/skills/nlpm/writing-skills/SKILL.md
+++ b/skills/nlpm/writing-skills/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: writing-skills
-description: "How to write SKILL.md files that trigger reliably and teach effectively. Use when creating, improving, or reviewing Claude Code skills."
-version: 0.1.0
+description: "How to write SKILL.md files that trigger reliably and teach effectively. Use when creating, improving, or reviewing skills for any tool — SKILL.md is the cross-tool open spec (agentskills.io), read identically by Claude Code, Codex CLI, and Antigravity."
+version: 0.2.0
 ---
 
 # Writing Skills
 
-> Scope: covers SKILL.md authoring. For agent writing, see [[writing-agents]]. For plugin architecture, see [[writing-plugins]].
+> Scope: covers SKILL.md authoring. SKILL.md is the **cross-tool open standard** (agentskills.io) — the same file works in Claude Code (`.claude/skills/`), Codex CLI (`.agents/skills/`), and Antigravity (`.agent/skills/`). Only `name` and `description` are required by the spec; per-tool extras (Claude's `model:`/`allowed-tools:`, Codex's `agents/openai.yaml` sidecar) live in `[[nlpm:conventions-claude]]` / `[[nlpm:conventions-codex]]` / `[[nlpm:conventions-antigravity]]`. For agent writing, see [[writing-agents]]. For plugin architecture, see [[writing-plugins]].
 
 ## 1. The Description is Everything
 


### PR DESCRIPTION
## Summary

**Option B** of the documentation staleness sweep — NLPM's own authoring-reference skills (the "how to write X" guides loaded on demand). They still framed every artifact as Claude-Code-only after the v1.0.0 multi-tool transition.

**Calibrated approach**: reframe scope and point to the per-tool `conventions-*` overlays, rather than triplicating every example into Claude/Codex/Antigravity variants. The conventions-* skills already hold the per-tool schemas; these guides teach the technique.

## Per-file treatment

| Skill | Change |
|---|---|
| `writing-skills` | **Worst error fixed** — described SKILL.md as "Claude Code skills" when it's the cross-tool open spec. Now: agentskills.io standard, read identically by Claude (`.claude/skills/`), Codex (`.agents/skills/`), Antigravity (`.agent/skills/`); per-tool extras point to conventions overlays |
| `writing-plugins` | Heaviest framing (7 mentions). Reframed description + added "other tools" scope block (Claude `.claude-plugin/`, Codex `.codex-plugin/` + `.agents/plugins/marketplace.json`, Antigravity `gemini-extension.json`, npx-skills path). Body examples stay Claude (concrete teaching); architecture reasoning noted as portable |
| `writing-hooks` | Scope note: hook event vocabularies are per-tool and NOT 1:1 mappable (decision #4), with pointers to all three event tables. Script-design principles transfer; event names + config locations don't |
| `writing-agents` | Clarified `.claude/agents/` Markdown agents are Claude-specific; Codex uses `[agents.*]` TOML |
| `writing-rules` | Clarified `.claude/rules/` is Claude-Code-specific; Codex/Antigravity use the hierarchical memory file (AGENTS.md/GEMINI.md) |
| `patterns` | Reframed intro + scope — patterns are tool-agnostic NL-writing best practices |
| `writing-prompts` | **NOT changed** — already correctly scoped as "universal prompt engineering for any LLM" with a pointer to the Claude-specific guides |

All six changed skills bumped to v0.2.0.

## Validation

- `python3 -m unittest tests.test_nlpm_check` — 23/23 pass.
- No body-example rewrites (Claude examples teach concretely); only scope/framing + pointers to per-tool conventions.

## Sweep complete

This finishes the doc-staleness investigation:
- **Option A + C** (top-level docs README/PRIVACY/security-scanner/AGENTS/for-authors/how-it-evolves + Gemini AGENTS.md verification) — PR #279, merged.
- **Option B** (authoring skills) — this PR.

Intentionally-historical docs (`analysis/`, `case-studies/`, `auditor/AUTH-LEAK.md`, version-log tables, the `conventions-claude` v0.7.15 incident reference) left untouched as the historical record.