### PR TITLE
rules: generalize R33-R39 from CLAUDE.md to the project memory file

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -15,7 +15,7 @@ Run `/nlpm:score` to enforce these rules. Run `/nlpm:fix` to auto-repair fixable
 | Shared Partials | R19-R20 | user-invocable: false, purpose description |
 | Rules | R21-R26 | Bold imperative + rationale, enforceable, budget, scoping |
 | Hooks | R27-R32 | Case-sensitive events, script existence, fail-open, block vs advise |
-| CLAUDE.md | R33-R39 | Build/test commands, architecture, no stale refs |
+| Memory file | R33-R39 | Build/test commands, architecture, no stale refs (CLAUDE.md / AGENTS.md / GEMINI.md) |
 | Prompts | R40-R42 | Five layers, exact output format, injection resistance |
 | Orchestration | R43-R47 | Parallel/sequential, QC gates, cost gates, retry limits |
-| Plugins | R48-R50 | Name required, CLAUDE.md vs README, four-place version bump |
+| Plugins | R48-R50 | Name required, memory file vs README, four-place version bump |

--- a/skills/nlpm/rules/SKILL.md
+++ b/skills/nlpm/rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rules
-description: "The 50 rules of natural language programming. Loaded when writing, reviewing, or improving any NL artifact — skills, agents, commands, rules, hooks, prompts, plugins, CLAUDE.md. The definitive style guide for NL code quality."
-version: 0.1.0
+description: "The 50 rules of natural language programming. Loaded when writing, reviewing, or improving any NL artifact — skills, agents, commands, rules, hooks, prompts, plugins, and the project memory file (CLAUDE.md / AGENTS.md / GEMINI.md). The definitive style guide for NL code quality."
+version: 0.2.0
 ---
 
 # The Rules of Natural Language Programming
@@ -111,9 +111,11 @@ Good: `**Use specific types instead of any.** Without specific types, TypeScript
 
 ---
 
-## CLAUDE.md
+## Memory file (CLAUDE.md / AGENTS.md / GEMINI.md)
 
-**R33. Include build/run command.** How to build and run the project. Without it, Claude guesses.
+> R33–R39 govern the project memory file. The rules use `CLAUDE.md` as the running example, but they apply identically to **AGENTS.md** (Codex CLI's native file, and nlpm's canonical universal memory file) and **GEMINI.md** (Antigravity / Gemini CLI). Substitute whichever file your project uses; in multi-tool projects, AGENTS.md is the canonical content and CLAUDE.md / GEMINI.md import it.
+
+**R33. Include build/run command.** How to build and run the project. Without it, the agent guesses.
 
 **R34. Include test command.** How to run tests. Without it, Claude skips verification.
 


### PR DESCRIPTION
## Summary

Tightens the last borderline item from the doc-staleness sweep. R33-R39 govern the project memory/context file — written with CLAUDE.md as the running example, but the principles apply identically to **AGENTS.md** (Codex native + nlpm's canonical universal memory file) and **GEMINI.md** (Antigravity / Gemini CLI).

## Light-touch generalization

No rewrite of each rule body — the bodies keep CLAUDE.md as the concrete example, which a new section note explicitly generalizes. This avoids verbose `CLAUDE.md / AGENTS.md / GEMINI.md` repetition on every line.

**`skills/nlpm/rules/SKILL.md`** (v0.1.0 → v0.2.0):
- Frontmatter trigger: "...plugins, CLAUDE.md" → "...plugins, and the project memory file (CLAUDE.md / AGENTS.md / GEMINI.md)"
- Section header `## CLAUDE.md` → `## Memory file (CLAUDE.md / AGENTS.md / GEMINI.md)` + a note that R33-R39 apply to whichever memory file the project uses, AGENTS.md canonical, CLAUDE.md/GEMINI.md import it in multi-tool projects
- R33 "Claude guesses" → "the agent guesses"

**`RULES.md`** (quick-reference table):
- "CLAUDE.md | R33-R39" → "Memory file | R33-R39 | ... (CLAUDE.md / AGENTS.md / GEMINI.md)"
- R48-R50 "CLAUDE.md vs README" → "memory file vs README"

## Validation

- `python3 -m unittest tests.test_nlpm_check` — 23/23 pass.
- No rule semantics changed — R33-R39 still check the same things; only the framing generalizes beyond CLAUDE.md.

This closes the doc-staleness investigation entirely (PR #279 top-level docs, PR #280 authoring skills, this PR the rulebook labels).