### PR TITLE
patterns + conventions: catch up from karpathy/autoresearch audit (P10/P11 + agent-workflow artifact note)

### DIFF
--- a/skills/nlpm/conventions/SKILL.md
+++ b/skills/nlpm/conventions/SKILL.md
@@ -98,6 +98,12 @@ This is exactly how nlpm itself is structured (`CLAUDE.md` → `@AGENTS.md`).
 
 **Tool-specific memory-file extensions** (e.g., Claude Code's `@`-import syntax, Gemini's `@{path}` injection, Codex's `project_doc_fallback_filenames`) live in the per-tool overlays.
 
+### Agent workflow programs (recognized variant, no penalty rubric yet)
+
+Some repos ship a single project-root Markdown file that drives an autonomous agent loop — imperative numbered steps with output formats and error paths, sitting between a memory file (AGENTS.md-shaped context) and a slash command (workflow with verifiable side effects). Karpathy's `program.md` in [`karpathy/autoresearch`](https://github.com/karpathy/autoresearch) is the canonical example (audited 2026-05-28 at score ~90; see [`auditor/exemplars/karpathy-autoresearch.md`](../../../auditor/exemplars/karpathy-autoresearch.md)). The README explicitly frames it as natural-language programming: "you are programming the `program.md` Markdown files that provide context to the AI agents."
+
+nlpm recognizes the pattern but does not yet have a dedicated penalty rubric — the universal floor (R01 vague quantifiers, R03 positive framing, R09 prompt layers) + the command rules (R14–R17) + the memory-file rules (R33–R39) cover it adequately as a hybrid. A standalone rubric is deferred until N≥3 examples surface, per the same "don't build for an empty corpus" discipline applied to multi-tool discovery.
+
 ---
 
 ## 3. General Prompt Engineering

--- a/skills/nlpm/patterns/SKILL.md
+++ b/skills/nlpm/patterns/SKILL.md
@@ -158,6 +158,43 @@ Each failure mode should produce a clear, actionable error message — not a sil
 
 ---
 
+### P10: Numeric Anchoring of Subjective Principles (R22)
+
+When stating a principle that has a subjective threshold ("simpler is better", "small change", "meaningful improvement"), follow it immediately with one or more numeric examples that cover the trade-space corners (best case, worst case, neutral case). The principle becomes testable instead of aspirational.
+
+**Example** (from karpathy/autoresearch `program.md:37`, scored 90/100 — see [`auditor/exemplars/karpathy-autoresearch.md`](../../../auditor/exemplars/karpathy-autoresearch.md) for the full audit):
+
+> "All else being equal, simpler is better. … A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 val_bpb improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep."
+
+The principle "simpler is better" alone fails R22 enforceability — different agents weigh "simpler" differently. The three anchored examples define the trade-space (gain × complexity-cost) by worked corner cases, so any agent following the rule reaches the same call on a borderline case.
+
+**Apply when** writing rules, agent constraints, or workflow instructions that include a subjective judgment word (small, meaningful, ugly, reasonable, simple, clean). Don't strip the subjective word — anchor it.
+
+---
+
+### P11: Paired CAN/CANNOT Contract (R03)
+
+When prohibitions are non-trivial, present capabilities and prohibitions as a paired list — "What you CAN do" / "What you CANNOT do" — rather than a stream of `do not`s. Each prohibition gains a positive complement; the agent reads both halves of the boundary in one pass.
+
+**Example** (from karpathy/autoresearch `program.md:25-31`):
+
+```
+**What you CAN do:**
+- Modify `train.py` — this is the only file you edit. Everything is fair game: model
+  architecture, optimizer, hyperparameters, training loop, batch size, model size, etc.
+
+**What you CANNOT do:**
+- Modify `prepare.py`. It is read-only…
+- Install new packages or add dependencies…
+- Modify the evaluation harness…
+```
+
+What makes this strong: prohibitions without alternatives are A2's Pink Elephant trap; the paired pattern structurally avoids it. The "CAN" half also doubles as a positive scope statement ("Everything is fair game") that prevents the agent from being overly conservative.
+
+**Apply when** an instruction set has more than two prohibitions on the same subject (file boundaries, tool boundaries, behavior boundaries). For a single prohibition, an inline "do X instead of Y" (P3) is enough.
+
+---
+
 ## Anti-Patterns (Avoid These)
 
 ### A1: Vague Quantifiers (R01)


### PR DESCRIPTION
## Summary

Two low-risk additions promoted from the karpathy/autoresearch exemplar (PR #286) to first-class rulebook guidance. Both are well-attested in that exemplar and have obvious cross-applicability.

## nlpm:patterns — two new patterns

- **P10: Numeric Anchoring of Subjective Principles** (anchors R22 enforceability). State the principle, anchor it with numeric corner-case examples. Karpathy's "A 0.001 val_bpb improvement that adds 20 lines? Probably not worth it. A 0.001 improvement from deleting code? Definitely keep." is the inaugural example.
- **P11: Paired CAN/CANNOT Contract** (R03 positive framing, structurally). When prohibitions are non-trivial, present capabilities + prohibitions as a paired list. Structurally avoids A2's Pink Elephant trap. Karpathy's "What you CAN do / CANNOT do" block is the canonical example.

## nlpm:conventions §2 — agent-workflow artifact note

A subsection recognizes "agent workflow programs" (project-root \`.md\` driving an autonomous loop, hybrid between AGENTS.md and a slash command) as a variant — but **no penalty rubric yet**. The universal floor + command rules + memory-file rules cover it adequately as a hybrid; standalone rubric deferred until N≥3 examples surface.

## Explicit deferrals

Two other patterns Karpathy demonstrates — *autonomy instruction with rationale + fallback ladder*, and *vivid closing use-case* — are **NOT promoted here**. N=1 risks over-fitting; deferred to \`auditor-cite-exemplars\` to surface them when more examples cluster.

## Validation

- Tests 23/23.
- Both patterns cite the karpathy exemplar by relative path for verification trail.