### PR TITLE
auditor: retire iannuttall/claude-agents as orphaned (PRs disabled)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "xiaolai/nlpm"
       },
       "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "xiaolai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Natural-Language Programming reference knowledge — the 50 Rules, the 100-point scoring rubric, per-tool conventions (Claude Code / Codex CLI / Antigravity), anti-patterns, vocabulary discipline, and authoring guides, as loadable Codex skills. The interactive linting commands remain a Claude Code plugin; the cross-tool deterministic checker ships as a standalone Python binary (bin/nlpm-check).",
   "author": {
     "name": "xiaolai"

--- a/auditor/SCHEMAS.md
+++ b/auditor/SCHEMAS.md
@@ -542,7 +542,7 @@ Not a log — a mutable state file, rewritten in place by the pipeline. Document
 
 | Field | Type | Written by | Notes |
 |-------|------|------------|-------|
-| `status` | enum | discover → batch → audit → contribute → track | One of `discovered`, `audited`, `contributed`, `tracked`, `complete`, `policy_denied`, `policy_cla_required` |
+| `status` | enum | discover → batch → audit → contribute → track | One of `discovered`, `audited`, `contributed`, `tracked`, `complete`, `policy_denied`, `policy_cla_required`, `orphaned` |
 | `audit_issue` | int | discover | Issue number in this repo, tracks the pipeline for the target |
 | `stars` | int | discover | Star count at discovery time |
 | `pipeline_prs` | array | contribute | PR numbers the auditor opened in the target repo |
@@ -551,10 +551,15 @@ Not a log — a mutable state file, rewritten in place by the pipeline. Document
 | `rule_adopted` | bool | track | `true` if the maintainer's own comments indicate rule-adoption |
 | `policy_no_external_prs` | bool | contribute | `true` if the owner is on the no-external-PR deny list (audit ran, contribute was skipped) |
 | `policy_cla_required` | bool | contribute | `true` if the owner requires a signed CLA (e.g., Google orgs) and the contributor identity has not signed (audit ran, contribute was skipped pending CLA) |
+| `terminal_reason` | enum | manual / future track | Why a repo entered the `orphaned` terminal state. Currently `prs_disabled`. |
+| `retired_at` | date | manual / future track | `YYYY-MM-DD` the repo was moved to `orphaned`. |
+| `retired_note` | string | manual / future track | Human-readable explanation of the retirement. |
 
 ### Status terminal states
 
 `policy_denied` (audit data captured, no PRs opened, repo is permanent dead-end for contribute) and `policy_cla_required` (audit data captured, no PRs opened, will become eligible once `vars.GOOGLE_CLA_SIGNED=true` is set on the workflow repo and the issue is re-labeled `contribute-approved`) are both terminal-but-recoverable states for the contribute pipeline. They never advance to `tracked`/`complete` automatically because no PRs exist to track. Daily report and rule-health filter on `status` to exclude these from "in flight" counts.
+
+`orphaned` is a terminal state for a repo where PRs **were** opened but can no longer be tracked through to an outcome because the target became unreachable — distinct from `policy_denied`/`policy_cla_required`, where no PRs were ever opened. The trigger seen in practice (2026-05-29, `iannuttall/claude-agents`): the maintainer disabled pull requests on the repository, so `gh pr view` returns *"Pull requests are disabled for this repository."* for every `pipeline_prs` entry. The track loop's `gh pr view ... || echo ""` swallows the failure and `continue`s, leaving `prs: []`; because the promotion gate at the bottom of the loop requires `jq length > 0`, the repo would otherwise sit in `contributed` forever, re-polling the dead PRs every 4 h and never reaching a case study. `orphaned` removes it from the track-poll `select(...)`. The `terminal_reason` field records the cause (`prs_disabled`; reserve room for `repo_deleted`, `repo_archived`, etc.). Like the policy states, `orphaned` is excluded from "in flight" counts and never auto-advances. The original `pipeline_prs` are preserved as the audit trail; the findings keep their last-observed `pr_state` in `events.jsonl` (no synthetic terminal `finding_outcome` is emitted, because the maintainer never adjudicated them — the door simply closed).
 
 ### PR record (`repos[owner/name].prs[i]`)
 

--- a/auditor/registry/repos.json
+++ b/auditor/registry/repos.json
@@ -4218,12 +4218,15 @@
         15
       ],
       "prs": [],
+      "retired_at": "2026-05-29",
+      "retired_note": "Maintainer disabled pull requests on the repository; pipeline_prs 12-15 can never merge or be tracked (gh pr view returns 'Pull requests are disabled for this repository.'). Excluded from the track-poll select().",
       "rule_adopted": false,
       "score": 88,
       "security": "CLEAR",
       "stars": 2046,
-      "status": "contributed",
-      "strategy": "single"
+      "status": "orphaned",
+      "strategy": "single",
+      "terminal_reason": "prs_disabled"
     },
     "itsmostafa/aws-agent-skills": {
       "artifacts": 18,


### PR DESCRIPTION
## Summary

`iannuttall/claude-agents` had 4 contribute PRs (#12–#15) opened, then the maintainer **disabled pull requests** on the repo. `gh pr view` now returns *"Pull requests are disabled for this repository."* for all four.

The track loop's `gh pr view ... || echo ""` swallows that failure and `continue`s, so `prs` stays `[]`. Because the promotion gate requires `jq length > 0`, the repo sat in `contributed` **forever** — re-polling 4 dead PRs every 4h and never advancing to a case study.

## Change

- New terminal status **`orphaned`** for repos where PRs *were* opened but can no longer be tracked (distinct from `policy_denied`/`policy_cla_required`, where none were opened).
- `iannuttall/claude-agents`: `status: contributed → orphaned`, plus `terminal_reason: "prs_disabled"`, `retired_at`, `retired_note`. `pipeline_prs` preserved as the audit trail.
- Documented in `SCHEMAS.md` (status enum + §Status terminal states + 3 new repo-record fields).

## Why no synthetic `finding_outcome`

The maintainer never adjudicated the findings — the door just closed. Emitting `closed_unmerged` would drag those rules' precision in rule-health (`accepted / (accepted + closed_unmerged)`), which would be wrong. Leaving them at last-observed `open` keeps them neutral.

## Verified

- Registry still valid JSON.
- Track's `select(status == contributed|tracked|complete)` no longer picks it up.
- `contributed` count 40 → 39, `orphaned` = 1.
- daily-report `group_by(.value.status)` absorbs the new value; rule-health (event-driven), discover (dedups by key), batch (`or "none"`) all unaffected.

## Out of scope (deliberately not done)

The 49 genuinely-open contribute PRs have **zero human maintainer engagement** (only review bots responded). Not closing them: on dead repos a close flips findings from `open`→`closed_unmerged` and corrupts rule-health for no maintainer benefit — `stale_90d` handles them neutrally. Not nudging active repos: burden risk; the PRs are visible and will be reached.