### PR TITLE
ci: harden pre-release gate — 35-min timeout + always-run/skip-pass

### DIFF
--- a/.github/workflows/pre-release-quality-gate.yml
+++ b/.github/workflows/pre-release-quality-gate.yml
@@ -22,9 +22,12 @@ name: Pre-Release Quality Gate
 # Triggers:
 #   - workflow_dispatch — manual run, e.g. before opening the release PR
 #     to verify cleanliness without making a plugin.json commit.
-#   - pull_request when plugin.json paths change — auto-fires on release
-#     PRs. Add this workflow to branch protection's required checks to make
-#     the gate truly blocking.
+#   - pull_request to main — fires on EVERY PR so the `gate` check always
+#     reports a status, which lets it be a required check in branch
+#     protection without blocking non-release PRs. The first job step
+#     detects whether a release manifest (.claude-plugin/plugin.json or
+#     .codex-plugin/plugin.json) actually changed; if not, the heavy
+#     scoring steps are skipped and the job passes trivially.
 #
 # NOT triggered on push to main — by then the PR has merged. The gate
 # belongs on the PR, before the marketplace propagation.
@@ -32,9 +35,8 @@ name: Pre-Release Quality Gate
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.claude-plugin/plugin.json'
-      - '.codex-plugin/plugin.json'
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -48,16 +50,43 @@ concurrency:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
+      - name: Detect release-bearing change
+        # The gate fires on every PR to main so `gate` can be a required
+        # check (a required check that never reports blocks the PR forever).
+        # Only release PRs — those that change a plugin manifest — need the
+        # expensive scoring. For all other PRs this step sets release=false
+        # and every heavy step below is skipped, so the job passes instantly.
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::workflow_dispatch — running full gate."
+            exit 0
+          fi
+          PR="${{ github.event.pull_request.number }}"
+          if gh pr diff "$PR" --repo "$GITHUB_REPOSITORY" --name-only \
+               | grep -qE '^\.(claude|codex)-plugin/plugin\.json$'; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release manifest changed — running full pre-release gate."
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No release manifest change — non-release PR, gate passes trivially."
+          fi
+
       - name: Set up Python
+        if: steps.detect.outputs.release == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
       - name: Deterministic floor — bin/nlpm-check
+        if: steps.detect.outputs.release == 'true'
         # Catches the cheap, deterministic failures first so we don't pay
         # the LLM cost when the basics are broken. Manifest-vs-disk diff,
         # required frontmatter, hook event-name case, valid JSON/TOML.
@@ -69,6 +98,7 @@ jobs:
           echo "::notice::Deterministic floor: clean."
 
       - name: LLM-judged score + vocab drift
+        if: steps.detect.outputs.release == 'true'
         id: llm_gate
         uses: anthropics/claude-code-action@v1
         env:
@@ -148,6 +178,7 @@ jobs:
               cluster count.
 
       - name: Assert gates
+        if: steps.detect.outputs.release == 'true'
         # Parses the two files the LLM step wrote and fails the workflow
         # on any sub-100 score or any drift cluster. Annotations land in
         # the PR's Files tab so the author sees them in context.
@@ -192,7 +223,7 @@ jobs:
       - name: Upload gate output as workflow artifact
         # Keep the per-file scores around for 30 days so historical
         # release-prep runs can be inspected.
-        if: always()
+        if: always() && steps.detect.outputs.release == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: pre-release-gate-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
## Summary

Prerequisite for making `gate` a required branch-protection check, split out from the v1.0.2 release PR (#292).

- **timeout-minutes 20 → 35** — the v1.0.2 gate run hit the 20-min cap mid-LLM-scoring (41 artifacts) and was killed before asserting.
- **Always-run / skip-pass** — trigger on every PR to `main` (drop the `plugin.json` paths filter) and add a "Detect release-bearing change" step. Non-release PRs skip all heavy steps and pass instantly, so `gate` always reports a status — required-check-safe without blocking non-release PRs.

## Why separate from #292

`claude-code-action` refuses to authenticate (401) when the PR's workflow file differs from the version on the default branch. Bundling this change into #292 made its gate unable to run. Landing it on `main` first lets #292's (identical) workflow authenticate.

This PR changes no manifest, so its own gate skips the LLM step and passes trivially.