### PR TITLE
ci: auditor PR-flow phase 1 — shared helper + migrate track

### DIFF
--- a/.github/workflows/auditor-track.yml
+++ b/.github/workflows/auditor-track.yml
@@ -340,6 +340,7 @@ jobs:
       - name: Log and commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           source auditor/scripts/log-event.sh
 
@@ -350,12 +351,7 @@ jobs:
 
           log_event "track" "status_check" "{\"contributed\": $CONTRIBUTED, \"tracked\": $TRACKED, \"case_study_ready\": $CASE_READY, \"rule_adopted\": $RULE_ADOPTED}"
 
-          git config user.name "nlpm-auditor[bot]"
-          git config user.email "nlpm-auditor[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add auditor/registry/repos.json auditor/logs/events.jsonl auditor/disagreements.jsonl
           bash auditor/scripts/guard-protected-paths.sh || exit 1
-          git diff --cached --quiet || {
-            git commit -m "track: $(date +%Y-%m-%d) — $TRACKED tracked, $CASE_READY case-study ready, $RULE_ADOPTED rule-adopted"
-            bash auditor/scripts/git-push-with-retry.sh
-          }
+          bash auditor/scripts/commit-via-pr.sh \
+            "track: $(date +%Y-%m-%d) — $TRACKED tracked, $CASE_READY case-study ready, $RULE_ADOPTED rule-adopted"

--- a/auditor/scripts/commit-via-pr.sh
+++ b/auditor/scripts/commit-via-pr.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# commit-via-pr.sh — commit staged auditor changes via a PR (auto-merged)
+# instead of pushing directly to main.
+#
+# Why this exists:
+#   Classic branch protection blocks any push that does not satisfy
+#   required status checks — including bot pushes via GITHUB_TOKEN.
+#   The auditor pipeline pushes to main every few hours (track,
+#   daily-report, dashboard, audit findings, etc.); with protection,
+#   those pushes are rejected (GH006). Opening a PR per bot commit
+#   threads the change through the same gate as humans. The gate's
+#   "Detect release-bearing change" step makes this cheap: non-release
+#   PRs (bot or human) skip the heavy LLM step and pass in seconds.
+#
+# Required environment:
+#   GITHUB_REPOSITORY, GITHUB_WORKFLOW, GITHUB_RUN_ID — set by Actions.
+#   PAT_TOKEN — repo PAT. Required so the bot PR triggers downstream
+#               workflows (PRs opened by GITHUB_TOKEN do NOT trigger
+#               them, by GitHub anti-recursion design). Falls back to
+#               GH_TOKEN if PAT_TOKEN is empty, but emits a warning:
+#               without PAT_TOKEN the gate workflow will not run on
+#               bot PRs, and once branch protection requires `gate`
+#               those PRs will sit unmerged.
+#
+# Usage:
+#   git add <files>
+#   bash auditor/scripts/commit-via-pr.sh "<commit message>"
+#
+# Behavior:
+#   - No-op (exit 0) if nothing is staged.
+#   - Otherwise: branch off origin/main, commit as nlpm-auditor[bot],
+#     push the branch (3 retries), open a PR labeled `auditor-bot`,
+#     enable auto-merge (merge-commit method).
+#
+# Concurrency note:
+#   Each bot run gets its own branch (auditor/bot/<workflow>/<run_id>),
+#   so branch pushes do not conflict between concurrent runs. Two bot
+#   PRs that touch the same file (e.g. events.jsonl) will conflict at
+#   merge time; the second auto-merge will sit until manually resolved
+#   or until the conflict clears. A future revision may add an
+#   auto-rebase loop here; for now, rare conflicts are accepted.
+
+set -euo pipefail
+
+MSG="${1:?usage: commit-via-pr.sh <commit message>}"
+
+# --- precondition: something staged? ---
+if git diff --cached --quiet; then
+  echo "commit-via-pr: nothing staged — skipping"
+  exit 0
+fi
+
+# --- choose the token. PAT_TOKEN preferred (so the bot PR triggers
+#     downstream workflows including the gate); fall back to GH_TOKEN
+#     with a warning. ---
+TOKEN="${PAT_TOKEN:-${GH_TOKEN:-}}"
+if [ -z "$TOKEN" ]; then
+  echo "::error::commit-via-pr requires PAT_TOKEN or GH_TOKEN in env" >&2
+  exit 1
+fi
+if [ -z "${PAT_TOKEN:-}" ]; then
+  echo "::warning::commit-via-pr: PAT_TOKEN missing — using GH_TOKEN. Bot PR will not trigger workflows; the gate will not run on it."
+fi
+
+# --- commit the staged tree on top of current HEAD as the bot identity.
+#     Actions/checkout leaves us at origin/main, so this commit is
+#     correctly parented on main. ---
+git -c user.name="nlpm-auditor[bot]" \
+    -c user.email="nlpm-auditor[bot]@users.noreply.github.com" \
+    commit -m "$MSG"
+HEAD_AFTER=$(git rev-parse HEAD)
+
+# --- create the bot branch pointing at the new commit ---
+SAFE_WF=$(echo "${GITHUB_WORKFLOW:-unknown-workflow}" | tr -c 'a-zA-Z0-9._-' '-')
+RUN_ID="${GITHUB_RUN_ID:-$(date +%s)}"
+BRANCH="auditor/bot/${SAFE_WF}/${RUN_ID}"
+git branch -f "$BRANCH" "$HEAD_AFTER"
+
+# --- push the branch via the chosen token ---
+git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+for attempt in 1 2 3; do
+  if git push -u origin "$BRANCH"; then
+    break
+  fi
+  if [ "$attempt" -eq 3 ]; then
+    echo "::error::commit-via-pr: push of $BRANCH failed after 3 attempts" >&2
+    exit 1
+  fi
+  echo "commit-via-pr: push attempt ${attempt}/3 failed; retrying"
+  sleep $((attempt * 3))
+done
+
+# --- open PR + enable auto-merge ---
+RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+BODY=$(printf 'Automated bot commit from `%s` ([run %s](%s)).\n\nMerged via the auditor PR-flow (see `auditor/scripts/commit-via-pr.sh`).' \
+       "${GITHUB_WORKFLOW:-unknown}" "$RUN_ID" "$RUN_URL")
+
+PR_URL=$(GH_TOKEN="$TOKEN" gh pr create \
+  --repo "$GITHUB_REPOSITORY" \
+  --base main --head "$BRANCH" \
+  --title "$MSG" --body "$BODY" \
+  --label "auditor-bot")
+echo "commit-via-pr: opened $PR_URL"
+
+# Auto-merge: lands as soon as required checks (if any) pass. When no
+# checks are required on main, --auto merges effectively immediately.
+if GH_TOKEN="$TOKEN" gh pr merge "$PR_URL" --auto --merge; then
+  echo "commit-via-pr: auto-merge enabled for $PR_URL"
+else
+  echo "::warning::commit-via-pr: --auto unavailable (auto-merge disabled on repo?); attempting direct merge"
+  GH_TOKEN="$TOKEN" gh pr merge "$PR_URL" --merge \
+    || { echo "::error::commit-via-pr: PR not merged — $PR_URL" >&2; exit 1; }
+fi


### PR DESCRIPTION
## Why

Classic branch protection rejects bot pushes to \`main\` (GH006), including pushes via \`GITHUB_TOKEN\` from the auditor workflows. The auditor pipeline commits to \`main\` every few hours (track, daily-report, dashboard, audit, …) — so the \"require \`gate\` check\" enforcement we want is fundamentally incompatible with the current direct-push pattern. The branch protection enabled earlier this week broke the pipeline for a week before I caught it.

This is **phase 1 of 3** to fix that:

| Phase | Scope |
|---|---|
| **1 (this PR)** | Shared helper + migrate \`auditor-track\` as proof of concept |
| 2 | Migrate the remaining ~8 push-to-main workflows |
| 3 | Recreate branch protection requiring \`gate\` |

## What's in this PR

- **\`auditor/scripts/commit-via-pr.sh\`** — shared helper. Branches off \`origin/main\`, commits as \`nlpm-auditor[bot]\`, opens a labelled bot PR, enables \`--auto --merge\`. No-op if nothing is staged.
- **\`auditor-track.yml\`** — first workflow migrated. Drops \`git config\` + \`set-url\` + \`git-push-with-retry.sh\` and calls the helper.

## Key design choice: PAT_TOKEN

The helper prefers \`PAT_TOKEN\` over \`GITHUB_TOKEN\`. **PRs opened by \`GITHUB_TOKEN\` do not trigger downstream workflows** (GitHub anti-recursion). Without \`PAT_TOKEN\`, the \`gate\` workflow would never run on bot PRs — and once protection is re-enabled in phase 3, the required check would never report and PRs would sit unmerged. \`PAT_TOKEN\` is already a project secret (per CLAUDE.md prerequisites).

## Verification plan after merge

Manually \`workflow_dispatch\` \`auditor-track\` and confirm:
1. A bot PR is opened against \`main\` (branch \`auditor/bot/Track*/<run_id>\`).
2. The \`gate\` check runs on it and reports success (skip-pass for non-release).
3. \`--auto --merge\` lands it without operator intervention.
4. \`events.jsonl\` on \`main\` carries the new \`status_check\` entry.

If any of those misbehave, phase 2 stops until phase 1 is debugged.

## Risk

Low. \`auditor-track\` is currently running successfully (since I removed the broken protection) via direct push. This PR changes only that one workflow's commit path; the other 9 keep pushing directly until phase 2. If the helper has a bug, only track is affected, and reverting this PR restores the pre-existing direct push.