### PR TITLE
ci: deterministic vocab gate — registry-enforced pairs; LLM clustering becomes advisory

### DIFF
--- a/.github/workflows/pre-release-quality-gate.yml
+++ b/.github/workflows/pre-release-quality-gate.yml
@@ -21,8 +21,15 @@ name: Pre-Release Quality Gate
 #      catching genuine multi-point defects. The deterministic floor
 #      (bin/nlpm-check) remains the exact, reproducible hard line.
 #
-#   2. VOCAB INTEGRITY GATE — zero vocabulary drift clusters detected by
-#      the vocab-drift-scanner on the nlpm corpus.
+#   2. VOCAB INTEGRITY GATE — deterministic: zero occurrences of
+#      registry-declared, enforce_terms-marked deprecated terms
+#      (auditor/scripts/registry-drift-check.py). The LLM
+#      vocab-drift-scanner still runs, but as ADVISORY output only —
+#      open-ended clustering is non-reproducible (each run judges the
+#      corpus afresh and can surface different clusters), which
+#      disqualifies it as a required check. Its job is to surface
+#      candidates for humans to curate into registry.yaml, where they
+#      become enforceable.
 #
 # Both gates must pass for release. Failures emit GitHub annotations and
 # block the PR; the score gate also writes /tmp/scores.tsv (kept as an
@@ -106,6 +113,25 @@ jobs:
             exit 1
           fi
           echo "::notice::Deterministic floor: clean."
+
+      - name: Deterministic vocab gate — registry-drift-check
+        if: steps.detect.outputs.release == 'true'
+        # The HARD vocab gate. Byte-deterministic: greps the corpus for
+        # terms the registry itself declares deprecated AND marks
+        # enforce_terms, honoring sanctioned (term, path) entries. Same
+        # corpus + same registry => same verdict, every run. The
+        # open-ended LLM clustering below is advisory only — five gate
+        # rounds on PR #708 each produced a different cluster set, which
+        # is disqualifying for a required check but exactly right for
+        # surfacing candidates to curate into the registry.
+        run: |
+          pip install --quiet pyyaml
+          python3 auditor/scripts/registry-drift-check.py --self-test
+          if ! python3 auditor/scripts/registry-drift-check.py --root .; then
+            echo "::error::Vocab gate FAILED — enforced registry-deprecated terms found (exact file:line above)."
+            exit 1
+          fi
+          echo "::notice::Vocab gate: clean (deterministic, registry-enforced pairs)."
 
       - name: LLM-judged score + vocab drift
         if: steps.detect.outputs.release == 'true'
@@ -219,14 +245,16 @@ jobs:
             fi
           fi
 
-          # --- Vocab integrity gate ---
+          # --- Vocab drift (ADVISORY) ---
+          # The hard vocab gate already ran deterministically in its own
+          # step. The LLM clustering below never fails the build: it
+          # surfaces candidates to curate into registry.yaml.
           if [ -s /tmp/drift.jsonl ]; then
             CLUSTERS=$(wc -l < /tmp/drift.jsonl | tr -d ' ')
-            echo "::error::Vocab integrity gate FAILED — $CLUSTERS drift cluster(s) detected:"
+            echo "::notice::Vocab drift advisory — $CLUSTERS candidate cluster(s) for registry curation (see artifact):"
             cat /tmp/drift.jsonl | head -20
-            FAILED=1
           else
-            echo "::notice::Vocab integrity gate PASSED — zero drift clusters."
+            echo "::notice::Vocab drift advisory — zero candidate clusters."
           fi
 
           if [ "$FAILED" -eq 1 ]; then

--- a/auditor/logs/events.jsonl
+++ b/auditor/logs/events.jsonl
@@ -3718,3 +3718,4 @@
 {"timestamp":"2026-07-31T20:42:46Z","workflow":"track","event":"status_check","run_id":"30663162396","run_number":627,"data":{"contributed":57,"tracked":37,"case_study_ready":42,"rule_adopted":2}}
 {"timestamp":"2026-07-31T22:19:59Z","workflow":"daily-report","event":"report_generated","run_id":"30669588955","run_number":119,"data":{"total_repos":280}}
 {"timestamp":"2026-07-31T22:47:05Z","workflow":"dashboard","event":"dashboard_rendered","run_id":"30671003448","run_number":75,"data":{"repos":280,"findings":5283,"advisories":22}}
+{"timestamp":"2026-08-01T00:52:29Z","workflow":"track","event":"status_check","run_id":"30676170206","run_number":628,"data":{"contributed":57,"tracked":37,"case_study_ready":42,"rule_adopted":2}}

--- a/auditor/scripts/registry-drift-check.py
+++ b/auditor/scripts/registry-drift-check.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Deterministic vocabulary-drift gate: registry-declared pairs only.
+
+Replaces open-ended LLM drift clustering as the hard vocab-integrity
+gate. The LLM clusterer (agents/vocab-drift-scanner.md) surfaces drift
+candidates a human curates into the registry; it is advisory. This
+script is the enforcement layer: it greps the corpus for terms the
+registry itself declares deprecated, and nothing else.
+
+Why: a hard release gate needs a bounded rule set, reproducible output,
+and a stable definition of "clean". Five consecutive gate runs on one
+release PR each produced a different cluster set (see nlpm PR #708) —
+an open-ended judge cannot certify a corpus clean because its bar moves
+every run. This scanner is byte-deterministic: same corpus + same
+registry => same findings.
+
+Contract:
+  - Only terms listed in a pair's `enforce_terms:` hard-fail. Terms
+    stay advisory until they grep clean against the current corpus
+    (common English words like "file" or "list" can never be
+    mechanically enforced; they stay advisory forever).
+  - Matches are word-boundary, case-insensitive, scope-aware: a file is
+    checked only against pairs whose registry scope covers it (the
+    auditor scope canonicalizes `validate`, which the internal scope
+    deprecates — per-scope application is what keeps that coherent).
+  - `sanctioned:` entries in registry.yaml suppress specific
+    (term, path-glob) pairs with a recorded reason — the machine-readable
+    counterpart of the SKILL.md sanctioned-homonyms table.
+  - A malformed registry (unreadable, duplicate canonical, enforced pair
+    with no deprecated terms, sanctioned entry missing term/path/reason)
+    fails the run — a gate that silently skips its rulebook is not a gate.
+
+Usage:
+  registry-drift-check.py [--root DIR] [--report-all] [--self-test]
+
+Exit codes: 0 clean, 1 enforced findings (or malformed registry),
+2 usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("registry-drift-check: PyYAML required", file=sys.stderr)
+    sys.exit(2)
+
+REGISTRY_PATH = "skills/nlpm/vocabulary/registry.yaml"
+
+# The gate's enumerated artifact set (mirrors the score gate's targets).
+# Codex mirrors are excluded: generated from the Claude tree.
+SCAN_GLOBS = [
+    "commands/*.md",
+    "commands/shared/*.md",
+    "agents/*.md",
+    "skills/nlpm/*/SKILL.md",
+    "AGENTS.md",
+]
+
+# Registry scope name -> path prefixes it covers (from registry.yaml's
+# scope declarations). A file outside every listed prefix for a scope is
+# not checked against that scope's pairs.
+SCOPE_PREFIXES = {
+    "internal": ("commands/", "agents/", "skills/", "bin/", "scripts/", "AGENTS.md", "CLAUDE.md"),
+    "auditor": ("auditor/", ".github/workflows/"),
+    # Noun scopes apply corpus-wide: artifact-class and output-class nouns
+    # name nlpm's own objects wherever they appear.
+    "artifact_class": ("",),
+    "output_class": ("",),
+}
+
+
+class RegistryError(Exception):
+    pass
+
+
+def load_registry(root: Path):
+    path = root / REGISTRY_PATH
+    try:
+        data = yaml.safe_load(path.read_text())
+    except Exception as e:
+        raise RegistryError(f"unreadable registry {path}: {e}")
+    if not isinstance(data, dict):
+        raise RegistryError("registry root is not a mapping")
+
+    pairs = []       # (scope, canonical, deprecated_terms, enforce)
+    seen = set()
+
+    def walk(node, scope):
+        if isinstance(node, dict):
+            if "canonical" in node:
+                canonical = node["canonical"]
+                key = (scope, canonical)
+                if key in seen:
+                    raise RegistryError(f"duplicate canonical {canonical!r} in scope {scope!r}")
+                seen.add(key)
+                dep = node.get("deprecated") or []
+                enforce_terms = node.get("enforce_terms") or []
+                unknown = [t for t in enforce_terms if t not in dep]
+                if unknown:
+                    raise RegistryError(
+                        f"{canonical!r} ({scope}) enforces terms not in its deprecated list: {unknown}")
+                if dep:
+                    pairs.append((scope, canonical, list(dep), list(enforce_terms)))
+                return
+            for k, v in node.items():
+                walk(v, k if scope is None else scope)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, scope)
+
+    for top, sub in data.items():
+        if top == "sanctioned":
+            continue
+        walk(sub, None if top in ("verbs", "nouns") else top)
+
+    sanctioned = data.get("sanctioned") or []
+    for entry in sanctioned:
+        if not isinstance(entry, dict) or not all(k in entry for k in ("term", "path", "reason")):
+            raise RegistryError(f"sanctioned entry missing term/path/reason: {entry!r}")
+
+    return pairs, sanctioned
+
+
+def scope_covers(scope: str, relpath: str) -> bool:
+    prefixes = SCOPE_PREFIXES.get(scope)
+    if prefixes is None:
+        # Unknown scope name: enforce nothing, but do not silently drop —
+        # surface as a registry problem.
+        raise RegistryError(f"registry declares unknown scope {scope!r}")
+    return any(relpath.startswith(p) or p == "" for p in prefixes)
+
+
+def is_sanctioned(sanctioned, term: str, relpath: str) -> bool:
+    return any(
+        e["term"].lower() == term.lower() and fnmatch.fnmatch(relpath, e["path"])
+        for e in sanctioned
+    )
+
+
+def scan(root: Path, pairs, sanctioned, report_all: bool):
+    findings = []
+    files = sorted({p for g in SCAN_GLOBS for p in root.glob(g) if p.is_file()})
+    for f in files:
+        rel = f.relative_to(root).as_posix()
+        lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+        for scope, canonical, deprecated, enforce_terms in pairs:
+            if not (enforce_terms or report_all):
+                continue
+            if not scope_covers(scope, rel):
+                continue
+            for term in deprecated:
+                enforced = term in enforce_terms
+                if not (enforced or report_all):
+                    continue
+                rx = re.compile(rf"\b{re.escape(term)}\b", re.IGNORECASE)
+                for lineno, line in enumerate(lines, 1):
+                    if not rx.search(line):
+                        continue
+                    if is_sanctioned(sanctioned, term, rel):
+                        continue
+                    findings.append({
+                        "file": rel, "line": lineno, "term": term,
+                        "canonical": canonical, "scope": scope,
+                        "enforced": enforced, "text": line.strip()[:160],
+                    })
+    return findings
+
+
+FIXTURE_REGISTRY = """\
+verbs:
+  internal:
+    - canonical: check
+      deprecated: [flurb]
+      enforce_terms: [flurb]
+    - canonical: score
+      deprecated: [grumble]
+nouns:
+  output_class:
+    - canonical: finding
+      deprecated: [snag]
+      enforce_terms: [snag]
+sanctioned:
+  - term: snag
+    path: "commands/teaching.md"
+    reason: quoted as data in a drift-teaching example
+"""
+
+FIXTURES = {
+    # positive: enforced term in scope -> finding
+    "commands/dirty.md": "Run the flurb pass over every artifact.\n",
+    # negative: sanctioned (term, path) -> suppressed
+    "commands/teaching.md": "Example of drift: calling a finding a snag.\n",
+    # negative: non-enforced pair -> advisory only
+    "agents/advisory.md": "The grumble step is optional.\n",
+    # negative: word-boundary — "flurbish" must not match "flurb"
+    "commands/boundary.md": "The flurbish quality is unrelated.\n",
+}
+
+
+def self_test() -> int:
+    failures = []
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "skills/nlpm/vocabulary").mkdir(parents=True)
+        (root / REGISTRY_PATH).write_text(FIXTURE_REGISTRY)
+        for rel, content in FIXTURES.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+        pairs, sanctioned = load_registry(root)
+        hard = scan(root, pairs, sanctioned, report_all=False)
+        soft = scan(root, pairs, sanctioned, report_all=True)
+
+        if [(f["file"], f["term"]) for f in hard] != [("commands/dirty.md", "flurb")]:
+            failures.append(f"hard findings wrong: {hard}")
+        if not any(f["term"] == "grumble" and not f["enforced"] for f in soft):
+            failures.append("advisory pair not reported in --report-all")
+        if any(f["file"] == "commands/teaching.md" for f in soft):
+            failures.append("sanctioned entry not suppressed")
+        if any(f["file"] == "commands/boundary.md" for f in soft):
+            failures.append("word boundary violated")
+
+        # determinism: two scans, identical output
+        if scan(root, pairs, sanctioned, True) != soft:
+            failures.append("scan is not deterministic")
+
+        # malformed registries must fail
+        for bad, why in [
+            ("verbs:\n  internal:\n    - canonical: check\n      deprecated: [x]\n      enforce_terms: [y]\n",
+             "enforce_terms references a term outside deprecated"),
+            ("verbs:\n  internal:\n    - canonical: x\n      deprecated: [y]\n    - canonical: x\n      deprecated: [z]\n",
+             "duplicate canonical"),
+            ("sanctioned:\n  - term: a\n", "sanctioned entry missing fields"),
+        ]:
+            (root / REGISTRY_PATH).write_text(bad)
+            try:
+                load_registry(root)
+                failures.append(f"malformed registry accepted: {why}")
+            except RegistryError:
+                pass
+
+    if failures:
+        for f in failures:
+            print(f"SELF-TEST FAIL: {f}", file=sys.stderr)
+        return 1
+    print("registry-drift-check.py self-tests: OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--report-all", action="store_true",
+                    help="also print advisory (non-enforced) findings; never affects exit code")
+    ap.add_argument("--json", action="store_true", help="JSONL output")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = Path(args.root).resolve()
+    try:
+        pairs, sanctioned = load_registry(root)
+        findings = scan(root, pairs, sanctioned, args.report_all)
+    except RegistryError as e:
+        print(f"::error::registry-drift-check: malformed registry — {e}", file=sys.stderr)
+        return 1
+
+    hard = [f for f in findings if f["enforced"]]
+    for f in findings:
+        tag = "error" if f["enforced"] else "notice"
+        if args.json:
+            print(json.dumps(f))
+        else:
+            print(f"::{tag} file={f['file']},line={f['line']}::"
+                  f"deprecated term '{f['term']}' (canonical: '{f['canonical']}', "
+                  f"scope: {f['scope']}): {f['text']}")
+    print(f"registry-drift-check: {len(hard)} enforced finding(s), "
+          f"{len(findings) - len(hard)} advisory", file=sys.stderr)
+    return 1 if hard else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/nlpm/vocabulary/registry.yaml
+++ b/skills/nlpm/vocabulary/registry.yaml
@@ -176,6 +176,8 @@ nouns:
   artifact_class:
     - canonical: artifact
       deprecated: [file, unit, component]
+      # 'component' is enforced via enforce_terms; 'file'/'unit' are generic English
+      enforce_terms: [component]
       definition: any NL programming file Claude Code consumes
     - canonical: command
       deprecated: [slash-command]
@@ -188,6 +190,7 @@ nouns:
       definition: skills/<plugin>/<name>/SKILL.md, auto-loaded by description match
     - canonical: rule
       deprecated: [guideline, convention]
+      enforce_terms: [guideline]
       definition: a numbered item inside skills/<plugin>/rules/SKILL.md
     - canonical: hook
       deprecated: [trigger]
@@ -197,19 +200,24 @@ nouns:
       definition: plugin.json or marketplace.json
     - canonical: frontmatter
       deprecated: [header, metadata-block]
+      enforce_terms: [metadata-block]
       definition: YAML block delimited by --- at top of a Markdown file
   output_class:
     - canonical: score
       deprecated: [grade, rating]
+      enforce_terms: [rating]
       definition: number 0-100 + penalty breakdown
     - canonical: finding
       deprecated: [issue, problem, defect]
+      # 'issue' enforced (GitHub-issue senses sanctioned below); 'problem'/'defect' generic
+      enforce_terms: [issue]
       definition: one problem detected; carries a fingerprint in auditor scope
     - canonical: violation
       deprecated: []
       definition: a finding specifically from cross-reference checking
     - canonical: penalty
       deprecated: [deduction]
+      enforce_terms: [deduction]
       definition: points subtracted by a single finding
     - canonical: snapshot
       deprecated: []
@@ -219,6 +227,7 @@ nouns:
       definition: list of artifacts discovered in a path
     - canonical: spec
       deprecated: [specification, test-case]
+      enforce_terms: [test-case]
       definition: a .nlpm-test/*.spec.md file defining expected behavior
   role_nouns:
     - canonical: scanner
@@ -233,3 +242,37 @@ nouns:
       paired_verb: scan
     - canonical: vague-scanner
       paired_verb: score  # sub-step
+
+# ── Sanctioned occurrences ────────────────────────────────────────────
+# Machine-readable counterpart of SKILL.md's sanctioned-homonyms table.
+# Each entry suppresses one (term, path-glob) pair for the enforcement
+# scanner (auditor/scripts/registry-drift-check.py) with the reason on
+# record. The advisory LLM clustering still sees everything.
+sanctioned:
+  - term: component
+    path: "skills/nlpm/rules/SKILL.md"
+    reason: R35/R49 "component map" — structural parts of the scored project's codebase, not NL artifacts
+  - term: component
+    path: "skills/nlpm/scoring/SKILL.md"
+    reason: R35 rubric row quotes the R35 sense
+  - term: component
+    path: "skills/nlpm/vocabulary/SKILL.md"
+    reason: the sanctioned-homonyms table quotes the term as data
+  - term: component
+    path: "skills/nlpm/writing-skills/SKILL.md"
+    reason: React-component teaching examples — a different domain's vocabulary
+  - term: issue
+    path: "AGENTS.md"
+    reason: GitHub issues — the platform object the auditor pipeline opens, labels, and closes
+  - term: issue
+    path: "skills/nlpm/security/SKILL.md"
+    reason: GitHub security/tracking issues the auditor files and links
+  - term: issue
+    path: "skills/nlpm/conventions-claude/SKILL.md"
+    reason: quotes a platform example argument list ("issue branch")
+  - term: issue
+    path: "skills/nlpm/vocabulary/SKILL.md"
+    reason: registry documentation quotes the term as data
+  - term: issue
+    path: "skills/nlpm/writing-agents/SKILL.md"
+    reason: user-voice dialogue in a trigger example ("debugging a production issue")


### PR DESCRIPTION
## Why

Five consecutive pre-release gate runs on #708 each produced a **different** drift-cluster set — rounds 4–5 flagged pairs outside the registry that no earlier run saw, after every previously cited cluster had been fixed. Full history in [the #708 diagnosis comment](https://github.com/xiaolai/nlpm/pull/708#issuecomment-5148683281). A hard gate needs a bounded rule set, reproducible output, and a stable definition of clean; open-ended LLM clustering has none of these — but it is exactly right for *surfacing candidates*. The score gate already encodes this distinction (threshold 95, not 100, for LLM variance); the vocab gate never got an equivalent mechanism.

Design reviewed via Codex consultation, which recommended this shape over both alternatives (admin-merge normalizes bypassing gates; fixing the gate inside the release PR it blocks is self-dealing).

## What

| Piece | Change |
|---|---|
| `auditor/scripts/registry-drift-check.py` | New byte-deterministic scanner: hard-fails only on terms the registry declares deprecated **and** marks in `enforce_terms`; word-boundary, case-insensitive, scope-aware; `sanctioned:` (term, path, reason) suppressions; malformed registry fails the run; `--self-test` ships positive/negative/sanctioned/word-boundary/determinism/malformed fixtures |
| `registry.yaml` | `enforce_terms` on the seven terms that grep clean against the #708 corpus (component, issue, guideline, metadata-block, rating, deduction, test-case) + ten sanctioned entries recording retained senses. Common-English deprecated terms stay advisory forever — `file` has 286 corpus hits, `config` 86, `list` 74: no mechanical gate can enforce them, which quantifies why the clusterer could never converge |
| `pre-release-quality-gate.yml` | Deterministic scanner becomes the hard vocab gate (own step, self-test first); the LLM vocab-drift-scanner still runs but its clusters are advisory output that never sets FAILED |

## Deliberate properties

- **No corpus prose edited here** — gate mechanics only, so the diff is reviewable in one sitting.
- Terms **graduate**: when an advisory term greps clean (e.g. after a cleanup like #708's), add it to `enforce_terms` and it locks.
- Verified against the #708 corpus: **0 enforced findings, exit 0** — after this merges, #708 rebases and passes the corrected policy on its own merits, no admin bypass.

## Verification

- `registry-drift-check.py --self-test` — OK
- 90 pytest + 23 subtests — pass
- Workflow YAML parses
- This PR touches no plugin manifest, so the heavy gate steps skip and it is not blocked by the gate it fixes