### PR TITLE
release: v1.2.0 — recut the vocabulary-canon release as a minor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "xiaolai/nlpm"
       },
       "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "author": {
         "name": "xiaolai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Natural-Language Programming reference knowledge — the 50 Rules, the 100-point scoring rubric, per-tool conventions (Claude Code / Codex CLI / Antigravity), anti-patterns, vocabulary discipline, and authoring guides, as loadable Codex skills. The interactive linting commands remain a Claude Code plugin; the cross-tool deterministic checker ships as a standalone Python binary (bin/nlpm-check).",
   "author": {
     "name": "xiaolai"


### PR DESCRIPTION
Re-cuts the just-shipped 1.1.3 as **1.2.0**. Versioning call: the release establishes new canonical vocabulary ('finding' deprecating 'issue'; 'artifact' deprecating 'component'), now enforced by the deterministic `registry-drift-check.py` gate. A canon change shifts downstream scoring behavior, so it signals a minor rather than a patch.

Content is byte-identical to 1.1.3 — only the version string changes, in all three plugin-repo files (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`). The central marketplace's three places are updated in a companion push.

The pre-release quality gate re-validates (all artifacts 100/100 + zero enforced vocab drift).