### PR TITLE
fix(discover): raise soft artifact ceiling to 250 + density heuristic to unstarve intake

### DIFF
--- a/.github/workflows/auditor-discover.yml
+++ b/.github/workflows/auditor-discover.yml
@@ -184,7 +184,27 @@ jobs:
             gh api "repos/$FULL_NAME/git/trees/HEAD?recursive=1" > /tmp/tree.json 2>/dev/null \
               || echo '{}' > /tmp/tree.json
 
-            ARTIFACT_COUNT=$(jq '[.tree[]?.path | select(
+            # Trust the tree before counting. A missing `.tree` means an API
+            # error or an empty (no-commit) repo — skip it (transient; the repo
+            # stays unregistered and is re-probed next run) rather than counting
+            # 0 and mislabeling it "below floor".
+            if ! jq -e 'has("tree")' /tmp/tree.json >/dev/null 2>&1; then
+              echo "  -> no tree (API error or empty repo) — skipping"
+              sleep 1
+              continue
+            fi
+            # A truncated response (>100k entries) is always a mega-repo whose
+            # partial counts can't be trusted — treat as oversized.
+            if [ "$(jq -r '.truncated // false' /tmp/tree.json 2>/dev/null)" = "true" ]; then
+              echo "  -> truncated tree (>100k entries) — skipping (mega-repo)"
+              echo "$repo" | jq '. + {skip_reason: "truncated_tree"}' >> /tmp/oversized.jsonl
+              sleep 1
+              continue
+            fi
+
+            # Count NL artifacts — blobs only, so a directory whose name matches
+            # a pattern can't inflate the count or the density denominator.
+            ARTIFACT_COUNT=$(jq '[.tree[]? | select(.type == "blob") | .path | select(
                 # Canonical Claude Code layouts
                 test("agents/.*\\.md$") or
                 test("commands/.*\\.md$") or

--- a/.github/workflows/auditor-discover.yml
+++ b/.github/workflows/auditor-discover.yml
@@ -22,9 +22,9 @@ on:
         type: number
         default: 5
       max_artifacts:
-        description: 'Maximum NL artifact count (above this, repo is likely generated/mirrored)'
+        description: 'Soft NL-artifact ceiling — above this a repo must pass the density check to stay worthy (see probe step)'
         type: number
-        default: 100
+        default: 250
 
 permissions:
   contents: write
@@ -151,9 +151,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MIN_ARTIFACTS: ${{ inputs.min_artifacts || 5 }}
-          MAX_ARTIFACTS: ${{ inputs.max_artifacts || 100 }}
+          MAX_ARTIFACTS: ${{ inputs.max_artifacts || 250 }}
+          # Above HARD_CEILING a repo is always a scraped/mirrored/generated
+          # mega-repo (thousands of files) — dropped regardless of density.
+          HARD_CEILING: 1000
+          # In the MAX_ARTIFACTS..HARD_CEILING band, keep repos whose NL
+          # artifacts are >= this percent of all files (curated, not scraped).
+          MIN_DENSITY_PCT: 15
         run: |
-          echo "Probe range: $MIN_ARTIFACTS <= artifacts <= $MAX_ARTIFACTS"
+          echo "Probe range: $MIN_ARTIFACTS <= artifacts <= $MAX_ARTIFACTS (hard ceiling $HARD_CEILING, min density ${MIN_DENSITY_PCT}%)"
           echo "[]" > /tmp/worthy.json
           : > /tmp/worthy_raw.jsonl   # truncate
           : > /tmp/oversized.jsonl    # truncate
@@ -171,8 +177,14 @@ jobs:
             # artifacts at `graphify/skill*.md` + AGENTS.md) was the
             # forcing function — the previous probe returned 0 for that
             # repo and silently dropped it from the queue.
-            ARTIFACT_COUNT=$(gh api "repos/$FULL_NAME/git/trees/HEAD?recursive=1" \
-              --jq '[.tree[].path | select(
+            # Fetch the recursive tree ONCE into a temp file and reuse it for
+            # both the artifact count and the total-file count. Reusing the
+            # payload (vs. a second API call) also computes the density signal
+            # for free.
+            gh api "repos/$FULL_NAME/git/trees/HEAD?recursive=1" > /tmp/tree.json 2>/dev/null \
+              || echo '{}' > /tmp/tree.json
+
+            ARTIFACT_COUNT=$(jq '[.tree[]?.path | select(
                 # Canonical Claude Code layouts
                 test("agents/.*\\.md$") or
                 test("commands/.*\\.md$") or
@@ -198,30 +210,48 @@ jobs:
                 # MCP / hooks at non-canonical paths
                 test("^\\.mcp\\.json$") or
                 test("hooks/hooks\\.json$")
-              )] | length' 2>/dev/null || echo 0)
+              )] | length' /tmp/tree.json 2>/dev/null || echo 0)
+
+            # Total file (blob) count — the denominator for the density check.
+            TOTAL_FILES=$(jq '[.tree[]? | select(.type == "blob")] | length' /tmp/tree.json 2>/dev/null || echo 0)
 
             # Empty repos return a 409 error body (not a tree), and transient
-            # API errors yield non-numeric output. Two guards are needed under
-            # `bash -e`: the `|| echo 0` above keeps the command substitution's
-            # exit status 0 so the assignment itself can't abort the step; the
-            # coercion below turns any leftover non-integer (e.g. a captured
-            # 409 JSON body) into 0 so the arithmetic tests can't crash either.
-            # Observed 2026-07-07: the empty repo Sfedfcv/redesigned-pancake
-            # killed a min_stars=200 sweep — first at the `[ -lt ]` test, then
-            # (after dropping `|| echo 0`) at the assignment itself.
-            case "$ARTIFACT_COUNT" in
-              ''|*[!0-9]*) ARTIFACT_COUNT=0 ;;
-            esac
+            # API errors yield non-numeric output. The `?` in `.tree[]?` plus
+            # `|| echo 0` keep the command substitutions from aborting the step
+            # under `bash -e`; the coercions below turn any leftover
+            # non-integer (e.g. a captured 409 JSON body) into 0 so the
+            # arithmetic tests can't crash either. Observed 2026-07-07: the
+            # empty repo Sfedfcv/redesigned-pancake killed a min_stars=200
+            # sweep at the `[ -lt ]` test.
+            case "$ARTIFACT_COUNT" in ''|*[!0-9]*) ARTIFACT_COUNT=0 ;; esac
+            case "$TOTAL_FILES" in ''|*[!0-9]*) TOTAL_FILES=0 ;; esac
 
             if [ "$ARTIFACT_COUNT" -lt "$MIN_ARTIFACTS" ]; then
               echo "  -> $ARTIFACT_COUNT artifacts — skipping (below floor)"
+            elif [ "$ARTIFACT_COUNT" -gt "$HARD_CEILING" ]; then
+              # Far over the ceiling — always a scraped/mirrored/generated
+              # mega-repo (thousands of files). Never worth an audit.
+              echo "  -> $ARTIFACT_COUNT artifacts — skipping (hard ceiling, scraped/mirrored)"
+              echo "$repo" | jq --argjson count "$ARTIFACT_COUNT" '. + {artifact_count: $count, skip_reason: "hard_ceiling"}' >> /tmp/oversized.jsonl
             elif [ "$ARTIFACT_COUNT" -gt "$MAX_ARTIFACTS" ]; then
-              # Oversized repos are usually generated, mirrored, or scraped —
-              # not curated plugins. Audit cost scales with artifact count, so
-              # we skip rather than burn LLM cycles. Recorded for review in
-              # case a legitimate large repo (rare) needs an explicit override.
-              echo "  -> $ARTIFACT_COUNT artifacts — skipping (above ceiling, likely generated/mirrored)"
-              echo "$repo" | jq --argjson count "$ARTIFACT_COUNT" '. + {artifact_count: $count, skip_reason: "above_artifact_ceiling"}' >> /tmp/oversized.jsonl
+              # Between the soft and hard ceilings. The old flat MAX=100
+              # silently dropped legitimate curated collections (e.g.
+              # microsoft/skills at 226, phuryn/pm-skills at 120) as
+              # "generated/mirrored". Separate curated from scraped by density:
+              # a curated repo is mostly NL artifacts; a scrape buries a few
+              # skills in a large tree.
+              if [ "$TOTAL_FILES" -gt 0 ]; then
+                DENSITY=$(( ARTIFACT_COUNT * 100 / TOTAL_FILES ))
+              else
+                DENSITY=0
+              fi
+              if [ "$DENSITY" -ge "$MIN_DENSITY_PCT" ]; then
+                echo "  -> $ARTIFACT_COUNT artifacts (${DENSITY}% density) — worthy (curated, over soft ceiling)"
+                echo "$repo" | jq --argjson count "$ARTIFACT_COUNT" --argjson density "$DENSITY" '. + {artifact_count: $count, density_pct: $density, rescued_over_ceiling: true}' >> /tmp/worthy_raw.jsonl
+              else
+                echo "  -> $ARTIFACT_COUNT artifacts (${DENSITY}% density) — skipping (over soft ceiling, low density = scraped)"
+                echo "$repo" | jq --argjson count "$ARTIFACT_COUNT" --argjson density "$DENSITY" '. + {artifact_count: $count, density_pct: $density, skip_reason: "low_density_over_ceiling"}' >> /tmp/oversized.jsonl
+              fi
             else
               echo "  -> $ARTIFACT_COUNT artifacts — worthy"
               echo "$repo" | jq --argjson count "$ARTIFACT_COUNT" '. + {artifact_count: $count}' >> /tmp/worthy_raw.jsonl


### PR DESCRIPTION
## Problem — the audit intake has been starved for ~14 days

The auditor's observation half (discover / track / classify / report) runs green daily, but the **outgoing half has been idle since 2026-07-20** — no new audits, no new PRs. Diagnosis: the discovery probe's flat `MAX_ARTIFACTS=100` "oversized" ceiling drops every repo with >100 NL artifacts as "likely generated/mirrored." As curated skill collections grew, `worthy` collapsed to **0** while `oversized` climbed **45 → 72**.

Today's oversized drops included **new, un-audited, legitimate** targets:

| Artifacts | Stars | Repo | Should be |
|---|---|---|---|
| 226 | 2.8k | `microsoft/skills` | **audited** (dropped) |
| 120 | 25k | `phuryn/pm-skills` | **audited** (dropped) |
| 6718 | 44k | `sickn33/agentic-awesome-skills` | dropped ✓ |
| 1639 | 237k | `affaan-m/ECC` | dropped ✓ |

One number can't separate a curated 226-skill collection from a 6,718-file scrape.

## Fix

- **Soft ceiling 100 → 250** — clean-pass zone; recovers all of today's legit drops.
- **Hard ceiling 1000** — always a scrape/mirror, dropped outright.
- **Density rescue (250–1000 band)** — keep repos whose NL artifacts are ≥15% of all files (curated); drop the rest (a scrape buries a few skills in a huge tree). The tree is fetched once and reused for both counts.

## Validation

`yaml.safe_load` OK · `bash -n` clean · jq expressions run. Classifier check: `microsoft/skills`(226)→worthy, `phuryn/pm-skills`(120)→worthy, curated-627→rescued, scraped-627→dropped, `ECC`(1639)→hard-drop.

Deliberately **not** widening intake blindly — the batch-processor's low-landing-rate suppression still gates what actually becomes a PR. This just stops the probe from throwing away good targets before they're ever seen.
