### PR TITLE
release: v1.2.2 — discover intake fix + probe hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "xiaolai/nlpm"
       },
       "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "xiaolai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Natural-Language Programming reference knowledge — the 50 Rules, the 100-point scoring rubric, per-tool conventions (Claude Code / Codex CLI / Antigravity), anti-patterns, vocabulary discipline, and authoring guides, as loadable Codex skills. The interactive linting commands remain a Claude Code plugin; the cross-tool deterministic checker ships as a standalone Python binary (bin/nlpm-check).",
   "author": {
     "name": "xiaolai"


### PR DESCRIPTION
## v1.2.2 (patch)

Cuts the release capturing #737 (already merged to main): the auditor's audit intake had been starved ~14 days because the flat `MAX_ARTIFACTS=100` "oversized" ceiling was dropping legit curated collections (e.g. `microsoft/skills`=226, `phuryn/pm-skills`=120) as "generated/mirrored."

**Contents since 1.2.1:**
- Discovery: soft ceiling 100→250, hard ceiling 1000, density rescue in between (NL-artifacts ÷ total-files ≥15%).
- Probe hardening (cc-suite audit-fix, Codex gpt-5.5): skip truncated (>100k) and API-errored/empty trees before counting; blob-filter the artifact numerator so a matching directory can't inflate count/density.

Version bump only in this PR; the logic already landed via #737.

### Verification
`bin/nlpm-check` clean · `python3 -m unittest tests.test_nlpm_check` 23/23. The workflow change was validated (yaml + `bash -n` + jq) and audit-verified independently before #737 merged.
