### PR TITLE
release: v1.2.3 — conventions-codex plugin.json field-type + marketplace policy-enum fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "xiaolai/nlpm"
       },
       "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "xiaolai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Natural-Language Programming reference knowledge — the 50 Rules, the 100-point scoring rubric, per-tool conventions (Claude Code / Codex CLI / Antigravity), anti-patterns, vocabulary discipline, and authoring guides, as loadable Codex skills. The interactive linting commands remain a Claude Code plugin; the cross-tool deterministic checker ships as a standalone Python binary (bin/nlpm-check).",
   "author": {
     "name": "xiaolai"

--- a/codex/skills/conventions-codex/SKILL.md
+++ b/codex/skills/conventions-codex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: conventions-codex
 description: Use when scoring or writing Codex CLI artifacts — covers .codex/config.toml schema, .codex-plugin/plugin.json, .agents/skills/ layout, Codex hook events, AGENTS.md hierarchy, marketplace.json, and the agents/openai.yaml sidecar. Refreshed 2026-08-02 against Codex 0.146.0 (2026-07-29).
-version: 0.3.0
+version: 0.3.1
 ---
 
 # Codex CLI Conventions
@@ -80,10 +80,10 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
   "name": "my-codex-plugin",
   "version": "1.0.0",
   "description": "Short summary",
-  "skills": ["./skills/foo"],
-  "mcpServers": ["./mcp/bar.toml"],
-  "apps": ["./apps/baz.app.json"],
-  "hooks": ["./hooks.json"],
+  "skills": "./skills/",
+  "mcpServers": "./mcp/servers.json",
+  "apps": "./apps/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "My Plugin",
     "longDescription": "Detailed description for installer UI"
@@ -92,7 +92,7 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
 ```
 
 **Required field:** `name` (kebab-case) — and only when a `plugin.json` is present at all. **All other top-level fields are optional**, including `version`, `description`, `author`, and `interface` (corrected 2026-08-02 against the vendor's `plugin-json-spec.md`; the earlier "version + description required" claim was wrong).
-**Optional artifact paths** (all relative `./` paths only): `skills`, `mcpServers`, `apps`, `hooks`.
+**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong.
 **Optional identity fields (added 2026-06):** `author` (`{name, email, url}`), `homepage`, `repository`, `license`, `keywords`.
 **Optional UI block** `interface`:
 - `displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`
@@ -126,8 +126,8 @@ Schema:
         "repo": "xiaolai/nlpm"
       },
       "policy": {
-        "installation": "auto",
-        "authentication": "none"
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
       },
       "category": "developer-tools",
       "interface": {
@@ -139,6 +139,8 @@ Schema:
 ```
 
 Per-plugin `source` types: `"github"`, `"git"`, `"local"`.
+
+**`policy` values are UPPERCASE enums** (corrected 2026-08-04 against nlpm's own shipping `.agents/plugins/marketplace.json`): `installation` e.g. `"AVAILABLE"`; `authentication` e.g. `"ON_USE"` or `"ON_INSTALL"`. The lowercase `"auto"`/`"none"` shown earlier was wrong — do NOT flag `AVAILABLE`/`ON_USE`/`ON_INSTALL` as invalid.
 
 ---
 

--- a/skills/nlpm/conventions-codex/SKILL.md
+++ b/skills/nlpm/conventions-codex/SKILL.md
@@ -92,7 +92,7 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
 ```
 
 **Required field:** `name` (kebab-case) — and only when a `plugin.json` is present at all. **All other top-level fields are optional**, including `version`, `description`, `author`, and `interface` (corrected 2026-08-02 against the vendor's `plugin-json-spec.md`; the earlier "version + description required" claim was wrong).
-**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; these paths are *supplemented on top of* default component discovery, not a replacement for it. Do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong — the array form the v0.3.0 overlay showed was incorrect.
+**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; these paths *supplement* Codex's default discovery, they do not replace it. Do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong — the array form the v0.3.0 overlay showed was incorrect.
 **Optional identity fields (added 2026-06):** `author` (`{name, email, url}`), `homepage`, `repository`, `license`, `keywords`.
 **Optional UI block** `interface`:
 - `displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`

--- a/skills/nlpm/conventions-codex/SKILL.md
+++ b/skills/nlpm/conventions-codex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: conventions-codex
-description: "Use when scoring or writing Codex CLI artifacts — covers .codex/config.toml schema, .codex-plugin/plugin.json, .agents/skills/ layout, Codex hook events, AGENTS.md hierarchy, marketplace.json, and the agents/openai.yaml sidecar. Refreshed 2026-08-02 against Codex 0.146.0 (2026-07-29)."
-version: 0.3.0
+description: "Use when scoring or writing Codex CLI artifacts — covers .codex/config.toml schema, .codex-plugin/plugin.json, .agents/skills/ layout, Codex hook events, AGENTS.md hierarchy, marketplace.json, and the agents/openai.yaml sidecar. Refreshed 2026-08-02 against Codex 0.146.0 (2026-07-29); §3/§4 field-type + policy-enum corrections 2026-08-04."
+version: 0.3.1
 ---
 
 # Codex CLI Conventions
@@ -80,10 +80,10 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
   "name": "my-codex-plugin",
   "version": "1.0.0",
   "description": "Short summary",
-  "skills": ["./skills/foo"],
-  "mcpServers": ["./mcp/bar.toml"],
-  "apps": ["./apps/baz.app.json"],
-  "hooks": ["./hooks.json"],
+  "skills": "./skills/",
+  "mcpServers": "./mcp/servers.json",
+  "apps": "./apps/",
+  "hooks": "./hooks.json",
   "interface": {
     "displayName": "My Plugin",
     "longDescription": "Detailed description for installer UI"
@@ -92,7 +92,7 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
 ```
 
 **Required field:** `name` (kebab-case) — and only when a `plugin.json` is present at all. **All other top-level fields are optional**, including `version`, `description`, `author`, and `interface` (corrected 2026-08-02 against the vendor's `plugin-json-spec.md`; the earlier "version + description required" claim was wrong).
-**Optional artifact paths** (all relative `./` paths only): `skills`, `mcpServers`, `apps`, `hooks`.
+**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; these paths are *supplemented on top of* default component discovery, not a replacement for it. Do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong — the array form the v0.3.0 overlay showed was incorrect.
 **Optional identity fields (added 2026-06):** `author` (`{name, email, url}`), `homepage`, `repository`, `license`, `keywords`.
 **Optional UI block** `interface`:
 - `displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`
@@ -126,8 +126,8 @@ Schema:
         "repo": "xiaolai/nlpm"
       },
       "policy": {
-        "installation": "auto",
-        "authentication": "none"
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
       },
       "category": "developer-tools",
       "interface": {
@@ -139,6 +139,8 @@ Schema:
 ```
 
 Per-plugin `source` types: `"github"`, `"git"`, `"local"`.
+
+**`policy` values are UPPERCASE enums** (corrected 2026-08-04 against nlpm's own shipping `.agents/plugins/marketplace.json` and observed real plugins): `installation` e.g. `"AVAILABLE"`; `authentication` e.g. `"ON_USE"` or `"ON_INSTALL"`. The lowercase `"auto"`/`"none"` the v0.3.0 overlay showed was wrong — do NOT flag `AVAILABLE`/`ON_USE`/`ON_INSTALL` as invalid.
 
 ---
 


### PR DESCRIPTION
## v1.2.3 (patch)

Two bugs in nlpm's own **Codex overlay**, surfaced by auditing three real Codex/Claude plugin repos (DannyMac180's sol-advisor / skills / fable-advisor) and verified against the vendor spec + nlpm's own shipping manifest:

- **`conventions-codex` §3** — `.codex-plugin/plugin.json` artifact-path fields (`skills`, `hooks`, `apps`) are **string** type, not array (`mcpServers` is string-or-object). The v0.3.0 overlay showed the array form, which nearly produced a **false positive** against sol-advisor's *correct* `"skills": "./skills/"`. Corrected against the vendor `plugin-json-spec.md`.
- **`conventions-codex` §4** — marketplace `policy` values are **UPPERCASE enums** (`installation: "AVAILABLE"`, `authentication: "ON_USE"`/`"ON_INSTALL"`), not the lowercase `auto`/`none` the overlay showed — which didn't even match nlpm's **own** live `.agents/plugins/marketplace.json`.

`conventions-codex` 0.3.0 → 0.3.1; `codex/` port mirror synced.

### Gate note
First real content release under the diff-scoped gate (#739) — it should score **only** the changed `skills/nlpm/conventions-codex/SKILL.md`, not the whole corpus.

### Verification
`bin/nlpm-check` clean · 23/23 tests · both `conventions-codex` copies at 0.3.1 with no wrong-form examples remaining.
