### PR TITLE
auditor: match repo-root SKILL.md in the discover probe; seed video-shotcraft

### DIFF
--- a/.github/workflows/auditor-discover.yml
+++ b/.github/workflows/auditor-discover.yml
@@ -213,6 +213,16 @@ jobs:
                 test("\\.claude/commands/.*\\.md$") or
                 test("\\.claude/agents/.*\\.md$") or
                 test("\\.claude/skills/.*/SKILL\\.md$") or
+                # Repo-root SKILL.md — the canonical single-skill layout in
+                # the open Agent Skills spec (the repo IS the skill dir).
+                # None of the patterns above anchor at the root: the
+                # `^[^/]+/SKILL\.md$` case below needs one leading
+                # directory, and the `skills/`-prefixed cases need that
+                # literal segment. Found 2026-08-07 auditing
+                # Vincentwei1021/video-shotcraft (3.7k stars, 660 files) —
+                # it probed at 1 artifact (`.claude-plugin/plugin.json`
+                # alone) and was invisible to discovery.
+                test("^SKILL\\.md$") or
                 # Multi-tool agent spec (becoming a standard for
                 # cross-assistant skill repos)
                 test("^AGENTS\\.md$") or

--- a/auditor/registry/repos.json
+++ b/auditor/registry/repos.json
@@ -1,9 +1,9 @@
 {
   "metadata": {
-    "last_discovery": "2026-08-05T02:07:37Z",
+    "last_discovery": "2026-08-07T04:33:32Z",
     "total_audited": 12,
     "total_contributed": 6,
-    "total_discovered": 272
+    "total_discovered": 273
   },
   "repos": {
     "0xNyk/council-of-high-intelligence": {
@@ -9770,6 +9770,17 @@
       "score": null,
       "audit_issue": 762,
       "prs": []
+    },
+    "Vincentwei1021/video-shotcraft": {
+      "discovered": "2026-08-07T04:33:32Z",
+      "stars": 3749,
+      "artifacts": 116,
+      "description": "AI video skill for Claude Code & Codex — cinematic product videos with Remotion: 106 shot recipe cards, 161 motion previews, a production-ready template",
+      "status": "discovered",
+      "score": null,
+      "audit_issue": 789,
+      "prs": [],
+      "discovery_strategy": "manual-seed"
     }
   }
 }


### PR DESCRIPTION
Two changes, one cause: `Vincentwei1021/video-shotcraft` is a 3.7k-star skill repo the pipeline could never have found.

## 1. Discover probe missed repo-root `SKILL.md`

The artifact-count expression in `auditor-discover.yml` had no pattern anchored at a repo-root `SKILL.md` — the canonical single-skill layout in the open Agent Skills spec, where the repo itself *is* the skill directory:

- `^[^/]+/SKILL\.md$` requires one leading directory
- `skills/.*/SKILL\.md$` and the `.claude/skills/...` variant require that literal segment

So a bare root `SKILL.md` matched nothing. `bin/nlpm-check` handles this layout fine (it rglobs for `SKILL.md`), which is why the gap went unnoticed — it is probe-specific.

**Blast radius, measured:** video-shotcraft has 660 files and ~116 NL artifacts. The probe scored it **1** (`.claude-plugin/plugin.json` alone) against `MIN_ARTIFACTS=5`. Invisible to discovery, and absent from all 280 registry entries.

Verified against the real tree: **1 → 2** after the fix.

## 2. Seeded the repo by hand

2 is still under the floor of 5, so the fix alone does not surface it. Seeded manually with `discovery_strategy: "manual-seed"` and audit issue #789; the registry write went through `atomic-registry-write.sh` and the metadata counters were bumped by the same jq discover uses.

## Open question, not addressed here

The probe counts *layout markers*, not the reference layer. video-shotcraft's actual NL surface is 104 shot cards under `references/shots/` plus 7 docs under `references/`, and no pattern reaches any of them — hence 2 rather than ~116. nlpm's own skills use `references/` the same way, so any repo shaped "one root skill + a large reference tree" is undercounted by roughly two orders of magnitude.

Whether the probe should count a skill's `references/**/*.md` is a real change to discovery breadth, so I left it alone rather than deciding it inside a bug fix.

## Verification

| Check | Result |
|---|---|
| `python3 -m unittest discover -s tests` | 90 passed |
| Registry JSON parse | valid |
| Workflow YAML parse | valid |
| `bin/nlpm-check .` | clean |
| jq expression against real 660-blob tree | 1 → 2 |

## Context

Manual audit of the repo at `0022ec4`: `nlpm-check` clean, security PASS, NL score 98 (SKILL.md 95, plugin.json 100, `agents/openai.yaml` 100). One finding, contributed upstream as Vincentwei1021/video-shotcraft#28. Expected to clear the exemplar gate once the pipeline audits it.