### PR TITLE
fix: move top-level version into metadata for Codex skill validation

### DIFF
--- a/codex/skills/conventions-antigravity/SKILL.md
+++ b/codex/skills/conventions-antigravity/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: conventions-antigravity
 description: Use when scoring or writing Antigravity (or legacy Gemini CLI) artifacts — covers .gemini/ paths, .agent/ workspace skills, gemini-extension.json, GEMINI.md, TOML slash commands, Gemini-lineage hook events. Spec is unsettled (Antigravity 2.0 launched 2026-05-19); many checks are advisory until PR-B verification.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Antigravity Conventions (with Gemini CLI legacy)

--- a/codex/skills/conventions-claude/SKILL.md
+++ b/codex/skills/conventions-claude/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: conventions-claude
 description: Use when scoring or writing Claude Code artifacts — covers .claude/ paths, plugin.json schema, command + agent + skill frontmatter, CLAUDE.md, hook events, hooks.json format, settings.json, LSP, monitors, memory file conventions, and the Claude Code built-in tool catalog. Refreshed 2026-08-02 against current docs (Claude Code ≥ v2.1.218).
-version: 0.3.0
+metadata:
+  version: 0.3.0
 ---
 
 # Claude Code Conventions

--- a/codex/skills/conventions-codex/SKILL.md
+++ b/codex/skills/conventions-codex/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: conventions-codex
 description: Use when scoring or writing Codex CLI artifacts — covers .codex/config.toml schema, .codex-plugin/plugin.json, .agents/skills/ layout, Codex hook events, AGENTS.md hierarchy, marketplace.json, and the agents/openai.yaml sidecar. Refreshed 2026-08-02 against Codex 0.146.0 (2026-07-29).
-version: 0.3.1
+metadata:
+  version: 0.3.1
 ---
 
 # Codex CLI Conventions

--- a/codex/skills/conventions/SKILL.md
+++ b/codex/skills/conventions/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: conventions
 description: "Universal NL programming conventions — SKILL.md open spec (agentskills.io), AGENTS.md as canonical universal memory file, vague-quantifier list, prompt engineering layers, naming conventions, the override system. Tool-specific schemas live in nlpm:conventions-claude / nlpm:conventions-codex / nlpm:conventions-antigravity."
-version: 0.2.1
+metadata:
+  version: 0.2.1
 ---
 
 # Universal NL Programming Conventions

--- a/codex/skills/orchestration/SKILL.md
+++ b/codex/skills/orchestration/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: orchestration
 description: Multi-agent workflow patterns for Claude Code -- parallel dispatch, sequential pipelines, QC gates, retry loops, shared partials. Use when designing systems with multiple agents, commands, or processing stages.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Orchestration

--- a/codex/skills/patterns/SKILL.md
+++ b/codex/skills/patterns/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: patterns
 description: Use when writing or reviewing NL artifacts and need to check for anti-patterns — vague quantifiers, prohibitions without alternatives, oversized skills, write-on-read-only agents, monolithic prompts, or linter-duplicating rules.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # NL Programming Patterns

--- a/codex/skills/rules/SKILL.md
+++ b/codex/skills/rules/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: rules
 description: The 50 rules of natural language programming. Loaded when writing, reviewing, or improving any NL artifact — skills, agents, commands, rules, hooks, prompts, plugins, and the project memory file (CLAUDE.md / AGENTS.md / GEMINI.md). The definitive style guide for NL code quality.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # The Rules of Natural Language Programming

--- a/codex/skills/scoring/SKILL.md
+++ b/codex/skills/scoring/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: scoring
 description: Use when scoring NL artifact quality, applying penalties, or calibrating lint judgment — contains the 100-point rubric with penalty tables per artifact type. Four worked calibration examples (Excellent Agent / Rewrite Agent / Excellent Rule / Weak Rule) live in `references/calibration-examples.md`, loaded on demand when anchoring borderline cases.
-version: 0.3.1
+metadata:
+  version: 0.3.1
 ---
 
 # NLPM Quality Scoring Rubric

--- a/codex/skills/security/SKILL.md
+++ b/codex/skills/security/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security
 description: Detects execution surface risks, supply chain vulnerabilities, data exfiltration vectors, and prompt injection patterns in Claude Code plugins. Use when auditing plugins for security risks, reviewing MCP server configurations, scanning hooks and scripts for vulnerabilities, or checking extensions before installation.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Security Scan Patterns for Claude Code Plugins

--- a/codex/skills/testing/SKILL.md
+++ b/codex/skills/testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: testing
 description: "Use when writing test specs for NL artifacts, running /nlpm:test, or setting up TDD workflows for skills, agents, commands, rules, hooks, and prompts."
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 ## The NL-TDD Cycle

--- a/codex/skills/vocabulary/SKILL.md
+++ b/codex/skills/vocabulary/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: vocabulary
 description: Use when writing, reviewing, or naming any NLPM artifact (command, agent, skill, rule, workflow) — pick the canonical noun or verb from this registry rather than coining a synonym. Loaded by the scorer and checker agents to detect vocabulary drift across artifacts.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # NLPM Domain Vocabulary

--- a/codex/skills/writing-agents/SKILL.md
+++ b/codex/skills/writing-agents/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-agents
 description: How to write Claude Code agents that trigger reliably, use the right model, and produce consistent output. Use when creating, improving, or reviewing agent definitions.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # Writing Agents

--- a/codex/skills/writing-hooks/SKILL.md
+++ b/codex/skills/writing-hooks/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-hooks
 description: How to write Claude Code hooks -- event selection, hook types, matcher patterns, blocking vs advisory, portable paths. Use when creating hooks for quality gates, automation, or policy enforcement.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # Writing Hooks

--- a/codex/skills/writing-plugins/SKILL.md
+++ b/codex/skills/writing-plugins/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-plugins
 description: How to design and build plugins -- architecture decisions, artifact selection, file structure, manifest configuration, marketplace publishing. Primarily Claude Code (.claude-plugin/plugin.json); the same architecture maps to Codex CLI (.codex-plugin/plugin.json) and Antigravity extensions. Use when planning, creating, or reviewing a plugin.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # Writing Plugins

--- a/codex/skills/writing-prompts/SKILL.md
+++ b/codex/skills/writing-prompts/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-prompts
 description: How to write effective system prompts for any LLM. Universal prompt engineering -- role clarity, structured output, injection resistance, few-shot examples. Use when writing prompts, system instructions, or AI configuration.
-version: 0.1.0
+metadata:
+  version: 0.1.0
 ---
 
 # Writing Prompts

--- a/codex/skills/writing-rules/SKILL.md
+++ b/codex/skills/writing-rules/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-rules
 description: How to write .claude/rules/ files that Claude actually follows. Use when creating, improving, or reviewing project rules.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # Writing Rules

--- a/codex/skills/writing-skills/SKILL.md
+++ b/codex/skills/writing-skills/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: writing-skills
 description: How to write SKILL.md files that trigger reliably and teach effectively. Use when creating, improving, or reviewing skills for any tool — SKILL.md is the cross-tool open spec (agentskills.io), read identically by Claude Code, Codex CLI, and Antigravity.
-version: 0.2.0
+metadata:
+  version: 0.2.0
 ---
 
 # Writing Skills


### PR DESCRIPTION
Codex CLI's `SKILL.md` frontmatter validation rejects a bare top-level `version:` field, so the 17 skills under `codex/skills/` fail validation on load.

This moves `version:` under `metadata:`, matching the structure Codex expects. Frontmatter restructure only — no content changes, and every `metadata.version` value is identical to the original top-level one.

Claude Code is unaffected either way: `version` is in its accepted frontmatter field set, so the marketplace build needs no change.

## Verification

All 17 skills load in Codex CLI 0.146.0 — confirmed via `codex debug prompt-input`, which renders the model-visible skill list without making an API call. All 17 appear with their `nlpm:` namespace and correct file paths.

Body content is untouched: the code samples inside `writing-skills/SKILL.md` that demonstrate frontmatter still show `version:` at the top level, since those are illustrative, not parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)