### PR TITLE
auditor: a manifest-vs-disk gap is an observation, not yet a defect

### DIFF
--- a/auditor/prompts/score-artifacts.md
+++ b/auditor/prompts/score-artifacts.md
@@ -244,18 +244,34 @@ Field rules:
     `allowed-tools` and grepped the artifact, finding zero call sites.
     Also `high`: missing required fields per `skills/nlpm/conventions/`
     where the schema is unambiguous (no `name:` on a SKILL.md).
-    Also `high`: **manifest-vs-disk diff** — when a plugin manifest
-    (`.claude-plugin/plugin.json` or similar) declares an array of
-    skills/agents/commands AND a disk file exists at a canonical
-    artifact path that's missing from that array, the gap is
-    deterministic: jq the array, find the files, diff. No judgment
-    required, reproduction takes 5 seconds. Mark as `high` and
-    populate `evidence` with the concrete diff (e.g., "plugin.json
-    skills array has 13 entries; disk has 17 SKILL.md files under
-    skills/; 4 misc/* directories missing from manifest"). The
-    2026-05-11 mattpocock/skills audit found 4 such bugs and the
-    scorer marked them all `medium` — under-confident on a class
-    of bug where the gap IS the evidence.
+    Also `high`: **manifest-vs-disk diff**, under one precondition.
+    When a plugin manifest (`.claude-plugin/plugin.json` or similar)
+    declares an array of skills/agents/commands AND a disk file exists
+    at a canonical artifact path missing from that array, the diff
+    itself is deterministic: jq the array, find the files, diff. The
+    diff is the observation. It is not yet the defect — a maintainer
+    is allowed to ship a subset and keep the rest in the tree.
+    What converts the observation into a bug is the **repo's own
+    written rule** that the manifest enumerates every artifact. Quote
+    that rule in `evidence` alongside the diff, e.g. "CLAUDE.md: every
+    skill in engineering/ or productivity/ must have an entry in
+    plugin.json; plugin.json skills array has 13 entries; disk has 17
+    SKILL.md files". With no such rule quoted, mark the finding `low`
+    and leave it in the audit data — an unexplained omission is
+    curation until the repo says otherwise.
+    When the rule exists and the manifest disagrees with it, the repo
+    contradicts itself and the maintainer chooses which side moves.
+    Write `suggested_fix` with both resolutions named — register the
+    artifacts, or narrow the rule to the buckets that ship — rather
+    than presuming the manifest is the side in error.
+    Precedent: the 2026-05-11 mattpocock/skills audit filed 4 such
+    findings, which the owner closed the same day with "Yep, this is
+    intentional". On 2026-07-01 he resolved the contradiction the
+    other way, demoting `misc/` to a non-promoted bucket and deleting
+    those 4 skills from the README rather than adding them to the
+    manifest. The contradiction was real; the proposed direction was
+    wrong, and naming one resolution as the fix is what made the
+    finding rejectable.
     Only `high` findings reach the contribute step; everything else
     stays in the audit data for our own learning.
   - `medium` — likely a bug but you cannot independently verify


### PR DESCRIPTION
auditor: a manifest-vs-disk gap is an observation, not yet a defect

The scoring prompt tells the scorer that a plugin manifest missing a
disk artifact is `high` confidence because "the gap IS the evidence".
That guidance was written from the 2026-05-11 mattpocock/skills audit,
and that audit is the case that refutes it.

What happened: 4 findings said the four `skills/misc/*` skills were
absent from `plugin.json`. Filed as issue #164 — that repo takes no
PRs. Matt closed it in 2h27m: "Yep, this is intentional."

Then on 2026-07-01, commit 7efc3d2a — "misc: demote to a non-promoted
bucket" — rewrote the CLAUDE.md rule from "every skill in engineering/,
productivity/, or misc/ must have an entry in plugin.json" to cover the
two promoted buckets only, and deleted the four Misc entries from the
top-level README. The commit body: "plugin.json already omitted misc,
so no manifest change was needed."

So the audit was half right in a way the prompt cannot currently
express. The contradiction was real — the repo's own rule mandated
registration and the manifest did not register. The maintainer agreed
enough to fix it 51 days later. But he fixed the rule, not the
manifest, and the finding had already named the manifest as the side
in error. A finding that presumes which side moves is rejectable even
when the inconsistency it found is genuine.

The correction:

- The diff stays deterministic, and stays the observation. It is not
  the defect. Shipping a subset and keeping the rest in the tree is
  a curation decision a maintainer is entitled to make.

- `high` now requires quoting the repo's own written rule that the
  manifest enumerates every artifact. With no such rule, the finding
  is `low` and stays in the audit data.

- When the rule exists and the manifest disagrees, `suggested_fix`
  must name both resolutions — register the artifacts, or narrow the
  rule to the buckets that ship.

- The mattpocock precedent is rewritten from supporting example to
  counter-example, with the demotion commit as the evidence.

Under this guidance issue #164 would have been filed as a question
about which side was authoritative, which is the question the
maintainer went on to answer himself.

Companion: #853 records the rejection that made this visible. It had
gone unrecorded for three months because auditor-track.yml polls pull
requests only and these findings were filed as an issue.

Scope note: BUG-missing-manifest-entry has fired 4 times in 1 repo and
has no definition in skills/nlpm/rules/. SCHEMAS says a BUG- id earns a
rulebook entry once it recurs; this one has not, so the fix lands in
the prompt that drives the scorer and the rulebook is untouched.

Verified: bin/nlpm-check clean; new text carries no R01 vague
quantifiers.
