### PR TITLE
rules: R01 does not fire on a term the artifact defines in situ

### DIFF
--- a/skills/nlpm/conventions/SKILL.md
+++ b/skills/nlpm/conventions/SKILL.md
@@ -135,6 +135,9 @@ The R01 rule penalizes unbounded quantifiers without measurable criteria. The pe
 - `relevant` in a markdown header (e.g., `## Relevant X`).
 - `relevant to <named-scope>` constructions (semantic "pertinent to").
 - Any term followed by a measurable criterion clause (e.g., "appropriate to the SLO target of 99.9% uptime").
+- Any term whose selection criteria the same artifact states ahead of the use — a table, list, or numbered procedure that binds each case to a named command, file, or value. The criterion does not have to sit in the same sentence; a later "run the `relevant` checks" pointing back to such a table is a reference, not a gap. Penalize when no such definition exists anywhere above the use, or when the definition is itself built from flagged terms.
+
+> Real-world example: `deepseek-ai/deepseek-harness` (audited 2026-08-14, score 97) — `.agents/skills/dsh-pre-push-checks/SKILL.md` scored 82 on nine occurrences of `relevant`, seven of them pointing back to its own `## Select relevant evidence` table, which binds each changed surface to a named command (documentation to `pnpm run doc-sync`, model-visible output to the owning keyless snapshot). The two that name no enumerated set — "the `relevant` `pnpm run test:e2e` target" and "when unit coverage is `relevant`" — are the genuine findings. Without this carve-out R01 penalizes the authors who define a selection rule and then refer to it by name, which is the structure that makes such a skill usable.
 
 See `nlpm:scoring` for the full vague-quantifier penalty table and cap (-2 each, -20 cap).
 


### PR DESCRIPTION
rules: R01 does not fire on a term the artifact defines in situ

R01 penalizes unbounded quantifiers *without measurable criteria*. Its
carve-out list currently covers three shapes: the term in a markdown
header, `relevant to <named-scope>`, and a term followed by a criterion
clause in the same sentence. All three require the criterion to sit next
to the use.

That misses the most common way a good skill actually supplies criteria:
define the selection rule once, under a heading, then refer to it by name
for the rest of the document. Under today's rule, doing that is penalized
once per reference.

Evidence from the 2026-08-14 deepseek-ai/deepseek-harness audit (#870):

`.agents/skills/dsh-pre-push-checks/SKILL.md` scores 82 — its lowest
file — on nine occurrences of `relevant`. The skill contains a section
headed `## Select relevant evidence` whose body is a decision table
binding each changed surface to a named command:

  package or script behavior  -> the owning Vitest file
  documentation / Agent Notes -> pnpm run doc-sync
  model-visible output        -> the owning keyless snapshot
  manifests / build config    -> pnpm run build + hygiene + built smoke
  real provider behavior      -> pnpm run test:e2e

Seven of the nine uses are references back to that table — "Run the
relevant evidence selected by this skill", "Confirm the relevant
non-platform evidence", "Run the selected relevant checks once". The
criteria exist, are measurable, and are stated ahead of every use. Two
uses do name no enumerated set — "the relevant `pnpm run test:e2e`
target" and "when unit coverage is relevant" — and those are recorded as
genuine findings in the audit.

So the rule fired nine times where the artifact was right seven of them,
and the seven misfires land on precisely the structure that makes the
skill usable. The same shape appears in dsh-code-review and
dsh-prose-standard in the same repo.

The carve-out states its own limits: it does not apply when no definition
exists above the use, nor when the definition is itself built from
flagged terms — otherwise "run the appropriate checks" could excuse
itself by pointing at a table of equally vague entries.

Scope: the carve-out list in nlpm:conventions §4, which is the file the
scorer loads. The rule statements in nlpm:rules R01 and nlpm:scoring
already read "without measurable criteria" and need no change.

Verified: bin/nlpm-check clean, 101 tests green, and every flagged term
in the new text sits inside backticks so the section does not trip its
own rule (the one bare `appropriate` in that region is the pre-existing
SLO example, itself covered by carve-out 3).

Data already landed by #870: the seven misfires are recorded as
false_positive findings carrying fp_reason and rule_gap, with matching
self_false_positive events. R01 moves to 11 self_fp on 611 hits (0.018
against a 0.20 noisy bar) and stays healthy.
