### PR TITLE
release: v1.2.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "repo": "xiaolai/nlpm"
       },
       "description": "Natural-Language Programming Manager \u2014 score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "author": {
         "name": "xiaolai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Natural-Language Programming Manager — score, check, fix, and test NL artifacts across Claude Code, Codex CLI, and Antigravity. Tier-aware scoring with per-tool overlays.",
   "author": {
     "name": "xiaolai"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlpm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Natural-Language Programming reference knowledge — the 50 Rules, the 100-point scoring rubric, per-tool conventions (Claude Code / Codex CLI / Antigravity), anti-patterns, vocabulary discipline, and authoring guides, as loadable Codex skills. The interactive linting commands remain a Claude Code plugin; the cross-tool deterministic checker ships as a standalone Python binary (bin/nlpm-check).",
   "author": {
     "name": "xiaolai"

--- a/codex/skills/conventions/SKILL.md
+++ b/codex/skills/conventions/SKILL.md
@@ -135,6 +135,9 @@ The R01 rule penalizes unbounded quantifiers without measurable criteria. The pe
 - `relevant` in a markdown header (e.g., `## Relevant X`).
 - `relevant to <named-scope>` constructions (semantic "pertinent to").
 - Any term followed by a measurable criterion clause (e.g., "appropriate to the SLO target of 99.9% uptime").
+- Any term whose selection criteria the same artifact states ahead of the use — a table, list, or numbered procedure that binds each case to a named command, file, or value. The criterion does not have to sit in the same sentence; a later "run the `relevant` checks" pointing back to such a table is a reference, not a gap. Penalize when no such definition exists anywhere above the use, or when the definition is itself built from flagged terms.
+
+> Real-world example: `deepseek-ai/deepseek-harness` (audited 2026-08-14, score 97) — `.agents/skills/dsh-pre-push-checks/SKILL.md` scored 82 on nine occurrences of `relevant`, seven of them pointing back to its own `## Select relevant evidence` table, which binds each changed surface to a named command (documentation to `pnpm run doc-sync`, model-visible output to the owning keyless snapshot). The two that name no enumerated set — "the `relevant` `pnpm run test:e2e` target" and "when unit coverage is `relevant`" — are the genuine findings. Without this carve-out R01 penalizes the authors who define a selection rule and then refer to it by name, which is the structure that makes such a skill usable.
 
 See `nlpm:scoring` for the full vague-quantifier penalty table and cap (-2 each, -20 cap).
 


### PR DESCRIPTION
release: v1.2.5

Patch bump. Everything since 1.2.4 is a correctness fix to the learning
loop or a refinement to an existing rule; no new commands, agents, or
skills, so this is not a minor.

- #853 record issue-lane maintainer dissent and make it countable
- #854 a manifest-vs-disk gap is an observation, not yet a defect
- #856 stop counting accepted PRs as maintainer dissent
- #870 audit: deepseek-ai/deepseek-harness (data only)
- #871 R01 does not fire on a term the artifact defines in situ

Also syncs codex/skills/conventions/SKILL.md, which #871 left behind.
The Claude and Codex copies of that skill are byte-identical mirrors, so
editing one side silently gave the two layouts different R01 carve-out
lists — three on the Codex side, four on the Claude side. Copied rather
than regenerated with build-codex.mjs: the converter rewrites all 20
files in the tree, and this needs one file to match exactly.

Version bumped in the three plugin-repo surfaces (.claude-plugin/
plugin.json, .codex-plugin/plugin.json, .claude-plugin/marketplace.json).
The central marketplace's two manifests and README follow after this
merges, per the six-place rule for dual-layout plugins.

Verified: bin/nlpm-check clean, 101 tests green, the two conventions
copies diff to zero lines.
