### PR TITLE
gate: score the Codex layout, and assert nothing else is unscorable

### DIFF
--- a/.github/workflows/pre-release-quality-gate.yml
+++ b/.github/workflows/pre-release-quality-gate.yml
@@ -153,8 +153,15 @@ jobs:
         # version-bump-only PR would be judged on 40+ untouched files. The
         # deterministic floor + vocab gate above stay whole-repo. A manual
         # workflow_dispatch scores everything (deliberate full sweep).
+        # The Codex layout is part of the pattern because those files ship to
+        # Codex users and are byte-identical mirrors of skills/nlpm/*. Omitting
+        # them made every codex/ artifact unscorable on every PR: v1.2.5 was cut
+        # with the two copies of the R01 carve-out list out of sync (four
+        # carve-outs on the Claude side, three on the Codex side) and no gate
+        # could see it. tests/test_gate_pattern_coverage.py now fails when a
+        # shipped NL artifact falls outside this pattern.
         run: |
-          NL_PATTERN='^(commands/[^/]+\.md|commands/shared/[^/]+\.md|agents/[^/]+\.md|skills/nlpm/[^/]+/SKILL\.md|AGENTS\.md|CLAUDE\.md|GEMINI\.md)$'
+          NL_PATTERN='^(commands/[^/]+\.md|commands/shared/[^/]+\.md|agents/[^/]+\.md|skills/nlpm/[^/]+/SKILL\.md|codex/skills/[^/]+/SKILL\.md|codex/AGENTS\.md|AGENTS\.md|CLAUDE\.md|GEMINI\.md)$'
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             git ls-files | grep -E "$NL_PATTERN" > /tmp/artifacts_to_score.txt || true
           else

--- a/codex/skills/conventions-codex/SKILL.md
+++ b/codex/skills/conventions-codex/SKILL.md
@@ -92,7 +92,7 @@ Duplicate-name skills across scopes are NOT merged — both appear in selectors,
 ```
 
 **Required field:** `name` (kebab-case) — and only when a `plugin.json` is present at all. **All other top-level fields are optional**, including `version`, `description`, `author`, and `interface` (corrected 2026-08-02 against the vendor's `plugin-json-spec.md`; the earlier "version + description required" claim was wrong).
-**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong.
+**Optional artifact paths — each a single relative-path STRING, not an array** (corrected 2026-08-04 against the vendor `plugin-json-spec.md`): `skills` (string), `hooks` (string), `apps` (string), `mcpServers` (string **or** object). A bare directory string like `"skills": "./skills/"` is the documented sample form; these paths *supplement* Codex's default discovery, they do not replace it. Do NOT flag a scalar-string `skills`/`hooks`/`apps`/`mcpServers` as wrong — the array form the v0.3.0 overlay showed was incorrect.
 **Optional identity fields (added 2026-06):** `author` (`{name, email, url}`), `homepage`, `repository`, `license`, `keywords`.
 **Optional UI block** `interface`:
 - `displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`
@@ -140,7 +140,7 @@ Schema:
 
 Per-plugin `source` types: `"github"`, `"git"`, `"local"`.
 
-**`policy` values are UPPERCASE enums** (corrected 2026-08-04 against nlpm's own shipping `.agents/plugins/marketplace.json`): `installation` e.g. `"AVAILABLE"`; `authentication` e.g. `"ON_USE"` or `"ON_INSTALL"`. The lowercase `"auto"`/`"none"` shown earlier was wrong — do NOT flag `AVAILABLE`/`ON_USE`/`ON_INSTALL` as invalid.
+**`policy` values are UPPERCASE enums** (corrected 2026-08-04 against nlpm's own shipping `.agents/plugins/marketplace.json` and observed real plugins): `installation` e.g. `"AVAILABLE"`; `authentication` e.g. `"ON_USE"` or `"ON_INSTALL"`. The lowercase `"auto"`/`"none"` the v0.3.0 overlay showed was wrong — do NOT flag `AVAILABLE`/`ON_USE`/`ON_INSTALL` as invalid.
 
 ---
 

--- a/codex/skills/rules/SKILL.md
+++ b/codex/skills/rules/SKILL.md
@@ -76,7 +76,7 @@ Mention versus use: a vague term presented as a literal token that the clause ex
 **R09. `<example>` blocks are mandatory.** Minimum 2. Each: Context (what user is doing) + user message + assistant response. Without them, triggering is unreliable.
 
 Bad: `<example>\nContext: User needs help\nuser: "help me"\nassistant: "I'll help."\n</example>`
-Good: `<example>\nContext: Developer refactoring auth module before PR\nuser: "Check if the auth changes have any security issues before I merge"\nassistant: "I'll dispatch the security-reviewer to audit the auth changes for vulnerabilities."\n</example>`
+Good: `<example>\nContext: Developer refactoring auth module before PR\nuser: "Check if the auth changes have any security vulnerabilities before I merge"\nassistant: "I'll dispatch the security-reviewer to audit the auth changes for vulnerabilities."\n</example>`
 
 <!-- nlpm-exemplar-citation:begin -->
 > Real-world example: [data-goblin-power-bi-agentic-development](../../../auditor/exemplars/data-goblin-power-bi-agentic-development.md), [matt1398-claude-devtools](../../../auditor/exemplars/matt1398-claude-devtools.md), [nicknisi-claude-plugins](../../../auditor/exemplars/nicknisi-claude-plugins.md), [ooiyeefei-ccc](../../../auditor/exemplars/ooiyeefei-ccc.md), [xiaolai-codex-toolkit-for-claude](../../../auditor/exemplars/xiaolai-codex-toolkit-for-claude.md), [xiaolai-grill-for-claude](../../../auditor/exemplars/xiaolai-grill-for-claude.md)

--- a/codex/skills/scoring/SKILL.md
+++ b/codex/skills/scoring/SKILL.md
@@ -411,10 +411,10 @@ Applied when linting an entire plugin rather than individual files.
 
 | Range | Label | Meaning |
 |-------|-------|---------|
-| 90–100 | Excellent | Production-ready; minor or no issues |
+| 90–100 | Excellent | Production-ready; minor or no findings |
 | 80–89 | Good | Solid; one or two non-critical gaps |
 | 70–79 | Adequate | Meets threshold; noticeable gaps to address |
-| 60–69 | Weak | Below threshold; significant issues |
+| 60–69 | Weak | Below threshold; significant findings |
 | <60 | Rewrite | Fundamental problems; recommend rewriting from scratch |
 
 **Default pass threshold:** 70. Configurable in `.claude/nlpm.local.md`.

--- a/tests/test_gate_pattern_coverage.py
+++ b/tests/test_gate_pattern_coverage.py
@@ -1,0 +1,149 @@
+"""The release gate's selection pattern must cover every shipped NL artifact.
+
+pre-release-quality-gate.yml scores only the NL artifacts a PR changed,
+selected by a single regex. An artifact outside that regex is not judged
+lower — it is never judged at all, on any PR, and the gate still reports
+green. Silently unscorable looks exactly like clean.
+
+That happened: `codex/skills/*/SKILL.md` sat outside the pattern from the
+day the Codex layout shipped. Those files are byte-identical mirrors of
+`skills/nlpm/*/SKILL.md`, so when the R01 carve-out list was edited on the
+Claude side only, the two layouts disagreed about the rule — four
+carve-outs for Claude users, three for Codex users — and v1.2.5 was cut
+that way with every check green.
+
+This test reads the pattern out of the workflow rather than restating it,
+so the workflow stays the single source of truth, and fails when a shipped
+artifact falls outside it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pre-release-quality-gate.yml"
+
+# Paths that look like NL artifacts to a filename check but are not scored:
+# placeholders that keep an empty directory in git, and tool config.
+NOT_ARTIFACTS = {
+    ".gemini/commands/.gitkeep",
+    ".gemini/skills/.gitkeep",
+    ".gemini/settings.json",
+}
+
+
+def gate_pattern() -> str:
+    """Extract NL_PATTERN from the workflow, unquoted."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r"^\s*NL_PATTERN='([^']+)'", text, re.M)
+    assert match, "NL_PATTERN not found in pre-release-quality-gate.yml"
+    return match.group(1)
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=REPO_ROOT,
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return out.split()
+
+
+def shipped_nl_artifacts(files: list[str]) -> list[str]:
+    """Every tracked file this repo ships that an NL scorer should judge."""
+    artifacts = []
+    for path in files:
+        if path in NOT_ARTIFACTS:
+            continue
+        name = path.rsplit("/", 1)[-1]
+        if name in ("SKILL.md", "AGENTS.md", "CLAUDE.md", "GEMINI.md"):
+            artifacts.append(path)
+        elif re.match(r"^(commands|agents)/.*\.md$", path):
+            artifacts.append(path)
+    return sorted(artifacts)
+
+
+class GatePatternCoverageTest(unittest.TestCase):
+    """pre-release-quality-gate.yml: NL_PATTERN covers what we ship."""
+
+    def setUp(self) -> None:
+        self.pattern = re.compile(gate_pattern())
+        self.files = tracked_files()
+
+    def test_every_shipped_nl_artifact_is_selectable(self) -> None:
+        artifacts = shipped_nl_artifacts(self.files)
+        self.assertGreater(len(artifacts), 40, "artifact discovery found too few files")
+        missed = [a for a in artifacts if not self.pattern.match(a)]
+        self.assertEqual(
+            missed, [],
+            "these shipped NL artifacts fall outside the release gate's "
+            "NL_PATTERN, so no PR can ever score them:\n  "
+            + "\n  ".join(missed)
+            + "\nAdd them to NL_PATTERN in "
+              ".github/workflows/pre-release-quality-gate.yml, or add them "
+              "to NOT_ARTIFACTS here with a reason.",
+        )
+
+    def test_codex_mirror_is_covered(self) -> None:
+        """The specific regression this test was written for."""
+        codex = [f for f in self.files if re.match(r"^codex/skills/[^/]+/SKILL\.md$", f)]
+        self.assertGreater(len(codex), 0, "no codex skills found — layout moved?")
+        for path in codex:
+            self.assertRegex(path, self.pattern)
+
+    def test_pattern_does_not_select_non_artifacts(self) -> None:
+        """A pattern that matches everything would pass the test above."""
+        for path in ("README.md", "package.json", "auditor/SCHEMAS.md",
+                     "docs/for-authors.md", "analysis/ecosystem-gap.md"):
+            self.assertIsNone(
+                self.pattern.match(path),
+                f"NL_PATTERN should not select {path}",
+            )
+
+
+def skill_body(path: Path) -> str:
+    """Everything after the YAML frontmatter."""
+    text = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\n.*?\n---\n", text, re.S)
+    return text[match.end():] if match else text
+
+
+class CodexMirrorParityTest(unittest.TestCase):
+    """A skill duplicated into codex/ must state the same rules as its source.
+
+    Bodies, not bytes: codex/ is build-codex.mjs output, and the converter
+    normalizes frontmatter (description quoting differs across the tree).
+    Frontmatter style is the converter's business. The body is the rulebook,
+    and the two layouts disagreeing about a rule is the defect.
+
+    Caught on first run: codex/skills/scoring said "minor or no issues" and
+    "significant issues" where the Claude source says "findings", and
+    codex/skills/rules said "security issues" for "security vulnerabilities".
+    nlpm's own vocabulary registry marks `issue` deprecated in favour of
+    `finding` with enforcement on, carving out only the GitHub-issue sense —
+    so the Codex tree was shipping a violation of the rule nlpm enforces on
+    every repo it audits.
+    """
+
+    def test_mirrored_skill_bodies_match(self) -> None:
+        mismatched = []
+        for codex_path in sorted(REPO_ROOT.glob("codex/skills/*/SKILL.md")):
+            source = REPO_ROOT / "skills" / "nlpm" / codex_path.parent.name / "SKILL.md"
+            if not source.exists():
+                continue
+            if skill_body(source) != skill_body(codex_path):
+                mismatched.append(codex_path.parent.name)
+        self.assertEqual(
+            mismatched, [],
+            "these skills state different rules in skills/nlpm/ and codex/"
+            "skills/, so Claude and Codex users are given different "
+            "instructions: " + ", ".join(mismatched)
+            + "\nRe-sync the body, or regenerate with build-codex.mjs.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
gate: score the Codex layout, and assert nothing else is unscorable

The release gate scores only the NL artifacts a PR changed, selected by
one regex. An artifact outside that regex is not scored lower — it is
never scored, on any PR, and the gate still reports green. Silently
unscorable is indistinguishable from clean.

`codex/skills/*/SKILL.md` has been outside that regex since the Codex
layout shipped: 18 artifacts that go to Codex users, unscorable by any
PR. v1.2.5 was cut with the two copies of the R01 carve-out list out of
sync — four carve-outs for Claude users, three for Codex — and every
check was green.

Adds `codex/skills/[^/]+/SKILL\.md` and `codex/AGENTS\.md` to NL_PATTERN.

The rest of this change is what the assertion found on its first run.

tests/test_gate_pattern_coverage.py reads NL_PATTERN out of the workflow
rather than restating it, enumerates every shipped NL artifact, and fails
when one falls outside. It also pins that the pattern does NOT match
README.md, package.json, or docs — a pattern matching everything would
pass the first assertion trivially.

Its companion checks that a skill mirrored into codex/ states the same
rules as its source. Bodies, not bytes: codex/ is build-codex.mjs output
and the converter normalizes frontmatter, so description quoting differs
across the tree and is the converter's business. The body is the
rulebook.

That check failed immediately on three skills, and the drift was nlpm
violating its own rule:

  codex/skills/scoring   "minor or no issues" / "significant issues"
                         where the source says "findings"
  codex/skills/rules     "security issues" for "security vulnerabilities"
  codex/skills/conventions-codex  two corrected-2026-08-04 lines stale

nlpm's vocabulary registry lists `finding` canonical and `issue`
deprecated with enforcement on, carving out only the GitHub-issue sense
(skills/nlpm/vocabulary/registry.yaml:210-213). So the Codex tree was
shipping a violation of the rule this project enforces on every repo it
audits, in the file that defines the rule.

Bodies re-synced from source, frontmatter left as the converter wrote it.
Hand-synced rather than regenerated: build-codex.mjs --force rewrites all
20 files, and this needed three bodies.

Verified: 105 tests green (4 new), bin/nlpm-check clean, zero remaining
body drift between the two trees.

Not fixed here: the full-sweep LLM gate still cannot run. Both dispatches
today failed on the seven-day rate limit for CLAUDE_CODE_OAUTH_TOKEN,
which resets 2026-08-15T00:00:00Z. The deterministic floor and the vocab
gate pass whole-repo; the LLM-judged 100/100 score remains unrun for
everything merged since 1.2.4.
